### PR TITLE
fix(cypress-tags): filter for several feature files

### DIFF
--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -21,7 +21,7 @@ function parseArgsOrDefault(argPrefix, defaultValue) {
   // otherwise it only accepts the last provided variable,
   // the way we replace here accomodates for that.
   const argValue = matchedArg
-    ? matchedArg.replace(new RegExp(`.*${argPrefix}=`), "").replace(/,.*/, "")
+    ? matchedArg.replace(new RegExp(`.*${argPrefix}=`), "").replace(/,*/, "")
     : "";
 
   return argValue !== "" ? argValue : defaultValue;


### PR DESCRIPTION
If your testcases begin with an id you can now pass them via CLI the same way, as you would via
cypress.json

fix #429