### PR TITLE
fix: call this.skip on it instead of cy context

### DIFF
--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -67,10 +67,7 @@ const runTest = (scenario, stepsToRun, rowData) => {
       const state = window.testState;
       cy.then(() => state.onStartScenario(scenario, indexedSteps))
         .then(() => state.onFinishScenario(scenario))
-        // eslint-disable-next-line func-names
-        .then(function () {
-          return this.skip();
-        });
+        .then(() => this.skip());
     });
   }
 };


### PR DESCRIPTION
We've experienced a similar issue to #440 where, after upgrading to cypress 5.6.0, skipped tests would throw an error stating `this.skip is not a function`.

We were able to fix this issue by calling `this.skip` on the context of the `it` handler instead of the `cy` handler. 

However, since the original developer explicitly used the context of `cy` it could be that this fix is not backwards compatible to cypress versions < 5.x

