### PR TITLE
Refactor: compile features in the loader rather than in the browser

### DIFF
--- a/lib/createTestsFromFeature.js
+++ b/lib/createTestsFromFeature.js
@@ -1,19 +1,16 @@
-const { CucumberDataCollector } = require("./cukejson/cucumberDataCollector");
-const { createTestFromScenarios } = require("./createTestFromScenario");
 const { shouldProceedCurrentStep, getEnvTags } = require("./tagsHelper");
 
-const createTestsFromFeature = (filePath, spec) => {
-  const testState = new CucumberDataCollector(filePath, spec);
-  const featureTags = testState.feature.tags;
+const createTestsFromFeature = (featureFile) => {
+  const featureTags = featureFile.tags;
   const hasEnvTags = !!getEnvTags();
   const anyFocused =
-    testState.feature.children.filter(
+    featureFile.children.filter(
       (section) => section.tags && section.tags.find((t) => t.name === "@focus")
     ).length > 0;
-  const backgroundSection = testState.feature.children.find(
+  const backgroundSection = featureFile.children.find(
     (section) => section.type === "Background"
   );
-  const allScenarios = testState.feature.children.filter(
+  const allScenarios = featureFile.children.filter(
     (section) => section.type !== "Background"
   );
 
@@ -36,9 +33,30 @@ const createTestsFromFeature = (filePath, spec) => {
     // eslint-disable-next-line no-param-reassign
     section.shouldRun = true;
   });
-  createTestFromScenarios(allScenarios, backgroundSection, testState);
+
+  return { allScenarios, backgroundSection };
+};
+
+const createTestTemplateFromFeature = (filePath, spec, featureFile) => {
+  const { allScenarios, backgroundSection } = createTestsFromFeature(
+    featureFile
+  );
+
+  return `
+    const testState = new CucumberDataCollector(
+      ${JSON.stringify(filePath)},
+      ${JSON.stringify(spec)},
+      ${JSON.stringify(featureFile)}
+    );
+    createTestFromScenarios(
+      ${JSON.stringify(allScenarios)},
+      ${JSON.stringify(backgroundSection)},
+      testState
+    );
+  `;
 };
 
 module.exports = {
   createTestsFromFeature,
+  createTestTemplateFromFeature,
 };

--- a/lib/cucumberTemplate.js
+++ b/lib/cucumberTemplate.js
@@ -10,7 +10,7 @@ const getPathFor = (file) => {
   return `${__dirname}/${file}`;
 };
 
-exports.cucumberTemplate = `  
+exports.cucumberTemplate = `
 const {
   resolveAndRunStepDefinition,
   defineParameterType,
@@ -23,6 +23,12 @@ const {
   After,
   defineStep
 } = require("${getPathFor("resolveStepDefinition")}");
+const { CucumberDataCollector } = require("${getPathFor(
+  "cukejson/cucumberDataCollector"
+)}");
+const { createTestFromScenarios } = require("${getPathFor(
+  "createTestFromScenario"
+)}");
 window.Given = Given;
 window.When = When;
 window.Then = Then;
@@ -30,7 +36,4 @@ window.And = And;
 window.But = But;
 window.defineParameterType = defineParameterType;
 window.defineStep = defineStep;
-const {
-  createTestsFromFeature
-} = require("${getPathFor("createTestsFromFeature")}");
 `;

--- a/lib/cukejson/cucumberDataCollector.js
+++ b/lib/cukejson/cucumberDataCollector.js
@@ -1,9 +1,8 @@
-const { Parser } = require("gherkin");
 const statuses = require("cucumber/lib/status").default;
 
 class CucumberDataCollector {
-  constructor(uri, spec) {
-    this.feature = new Parser().parse(spec.toString()).feature;
+  constructor(uri, spec, feature) {
+    this.feature = feature;
     this.scenarioSteps = {};
     this.runScenarios = {};
     this.runTests = {};

--- a/lib/cukejson/cucumberDataCollector.test.js
+++ b/lib/cukejson/cucumberDataCollector.test.js
@@ -1,5 +1,6 @@
 const fs = require("fs");
 const statuses = require("cucumber/lib/status").default;
+const { Parser } = require("gherkin");
 const { CucumberDataCollector } = require("./cucumberDataCollector");
 const { generateCucumberJson } = require("./generateCucumberJson");
 
@@ -87,7 +88,8 @@ describe("Cucumber Data Collector", () => {
   beforeEach(() => {
     const filePath = "./cypress/integration/Plugin.feature";
     const spec = fs.readFileSync(filePath);
-    this.testState = new CucumberDataCollector(filePath, spec);
+    const parsedFeature = new Parser().parse(spec.toString()).feature;
+    this.testState = new CucumberDataCollector(filePath, spec, parsedFeature);
     this.testState.onStartTest();
   });
 

--- a/lib/featuresLoader.js
+++ b/lib/featuresLoader.js
@@ -3,7 +3,6 @@ const path = require("path");
 const fs = require("fs");
 const { Parser } = require("gherkin");
 const log = require("debug")("cypress:cucumber");
-const jsStringEscape = require("js-string-escape");
 
 const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 const { cucumberTemplate } = require("./cucumberTemplate");
@@ -11,6 +10,7 @@ const { getCucumberJsonConfig } = require("./getCucumberJsonConfig");
 const {
   isNonGlobalStepDefinitionsMode,
 } = require("./isNonGlobalStepDefinitionsMode");
+const { createTestTemplateFromFeature } = require("./createTestsFromFeature");
 
 const createCucumber = (
   specs,
@@ -53,21 +53,19 @@ const createCucumber = (
 
   ${specs
     .map(
-      ({ spec, filePath, name }) => `
-        describe(\`${name}\`, function() {
-        window.currentFeatureName = \`${name}\`
-        ${
-          nonGlobalToRequire &&
-          nonGlobalToRequire
-            .find((fileSteps) => fileSteps[filePath])
-            [filePath].join("\n")
-        }
+      ({ spec, filePath, name, document }) => `
+          describe(\`${name}\`, function() {
+            window.currentFeatureName = \`${name}\`
+            ${
+              nonGlobalToRequire &&
+              nonGlobalToRequire
+                .find((fileSteps) => fileSteps[filePath])
+                [filePath].join("\n")
+            }
 
-        createTestsFromFeature('${path.basename(filePath)}', '${jsStringEscape(
-        spec
-      )}');
-        })
-        `
+            ${createTestTemplateFromFeature(filePath, spec, document)}
+          });
+      `
     )
     .join("\n")}
   `;
@@ -109,10 +107,14 @@ module.exports = function (_, filePath = this.resourcePath) {
       spec: fs.readFileSync(featurePath).toString(),
       filePath: featurePath,
     }))
-    .map((feature) => ({
-      ...feature,
-      name: new Parser().parse(feature.spec.toString()).feature.name,
-    }));
+    .map((feature) => {
+      const parsedFeature = new Parser().parse(feature.spec.toString()).feature;
+      return {
+        ...feature,
+        name: parsedFeature.name,
+        document: parsedFeature,
+      };
+    });
 
   return createCucumber(
     specs,

--- a/lib/loader.js
+++ b/lib/loader.js
@@ -1,21 +1,27 @@
 const log = require("debug")("cypress:cucumber");
 const path = require("path");
 const { Parser } = require("gherkin");
-const jsStringEscape = require("js-string-escape");
 const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 const { cucumberTemplate } = require("./cucumberTemplate");
 const { getCucumberJsonConfig } = require("./getCucumberJsonConfig");
+const { createTestTemplateFromFeature } = require("./createTestsFromFeature");
 
 // This is the template for the file that we will send back to cypress instead of the text of a
 // feature file
-const createCucumber = (filePath, cucumberJson, spec, toRequire, name) =>
+const createCucumber = (
+  filePath,
+  cucumberJson,
+  spec,
+  toRequire,
+  parsedFeature
+) =>
   `
   ${cucumberTemplate}
 
   window.cucumberJson = ${JSON.stringify(cucumberJson)};
-  describe(\`${name}\`, function() {
+  describe(\`${parsedFeature.name}\`, function() {
     ${toRequire.join("\n")}
-    createTestsFromFeature('${filePath}', '${jsStringEscape(spec)}');
+    ${createTestTemplateFromFeature(filePath, spec, parsedFeature)};
   });
   `;
 
@@ -26,12 +32,12 @@ module.exports = function (spec, filePath = this.resourcePath) {
     (sdPath) => `require('${sdPath}')`
   );
 
-  const { name } = new Parser().parse(spec.toString()).feature;
+  const parsedFeature = new Parser().parse(spec.toString()).feature;
   return createCucumber(
     path.basename(filePath),
     getCucumberJsonConfig(),
     spec,
     stepDefinitionsToRequire,
-    name
+    parsedFeature
   );
 };

--- a/lib/resolveStepDefinition.test.js
+++ b/lib/resolveStepDefinition.test.js
@@ -48,10 +48,7 @@ describe("Tags implementation", () => {
 });
 
 describe("Tags with env TAGS set", () => {
-  window.Cypress = {
-    ...window.Cypress,
-    env: () => "@test-tag and not @ignore-tag",
-  };
+  process.env.TAGS = "@test-tag and not @ignore-tag";
   require("../cypress/support/step_definitions/tags_implementation_with_env_set");
   resolveFeatureFromFile(
     "./cypress/integration/TagsImplementationWithEnvSet.feature"
@@ -63,10 +60,7 @@ describe("Tags with env TAGS set", () => {
 });
 
 describe("Smart tagging", () => {
-  window.Cypress = {
-    ...window.Cypress,
-    env: () => "",
-  };
+  process.env.TAGS = "";
   require("../cypress/support/step_definitions/smart_tagging");
   resolveFeatureFromFile("./cypress/integration/SmartTagging.feature");
 });

--- a/lib/tagsHelper.js
+++ b/lib/tagsHelper.js
@@ -1,7 +1,7 @@
 const { TagExpressionParser } = require("cucumber-tag-expressions");
 
 function getEnvTags() {
-  return Cypress.env("TAGS") || "";
+  return process.env.TAGS || "";
 }
 
 function shouldProceedCurrentStep(tags = [], envTags = getEnvTags()) {

--- a/lib/testHelpers/resolveFeatureFromFile.js
+++ b/lib/testHelpers/resolveFeatureFromFile.js
@@ -1,11 +1,22 @@
 /* eslint-disable global-require */
 const fs = require("fs");
+const { Parser } = require("gherkin");
 
 const { createTestsFromFeature } = require("../createTestsFromFeature");
+const { createTestFromScenarios } = require("../createTestFromScenario");
+const { CucumberDataCollector } = require("../cukejson/cucumberDataCollector");
 
 const resolveFeatureFromFile = (featureFile) => {
   const spec = fs.readFileSync(featureFile);
-  createTestsFromFeature(featureFile, spec);
+  const parsedFeature = new Parser().parse(spec.toString()).feature;
+
+  const { filePath, allScenarios, backgroundSection } = createTestsFromFeature(
+    parsedFeature
+  );
+
+  const testState = new CucumberDataCollector(filePath, spec, parsedFeature);
+
+  createTestFromScenarios(allScenarios, backgroundSection, testState);
 };
 
 module.exports = {


### PR DESCRIPTION
This change moves where the feature files are compiled from inside the browser to wherever the loader is being run (hopefully Cypress node!). 

This came about as I was trying to integrate this plugin with rollup preprocessor instead of webpack or browserify, I noticed that the end test bundle was huge (40k lines!). I'm not certain of the performance improvement this brings but regardless, parsing the feature file for the name in the loader then discarding that is somewhat wasteful. 

While all the tests pass, there is one part I am not so sure about, and that is my change to `getEnvTags()` I made this logic run in the loader too and used `process.env.TAGS` instead of `Cypress.env()`. I am yet to check if that is a valid change and would be grateful if in the meantime you could hint if thats outright unacceptable - if so I'll modify this to be something that happens at test run time.

Please feel free to ask any questions or just outright decline if I have made a bad call here and this was done like this for a reason. 

Thanks,
Tom