### PR TITLE
Handle periods in feature filenames better

### DIFF
--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -75,7 +75,7 @@ const runTest = (scenario, stepsToRun, rowData) => {
   }
 };
 
-const cleanupFilename = (s) => s.split(".")[0];
+const cleanupFilename = (s) => s.replace(/\.[^.]*$/, "");
 
 const writeCucumberJsonFile = (json) => {
   const outputFolder =


### PR DESCRIPTION
Drop only the part of the filename after the last period (`.`) during cleanup, instead of removing everything after the first period.

The reason for this is this naming scheme (not my call!):

```
behind-the-scenes.age-pension.feature
behind-the-scenes.contribution-rate.feature
behind-the-scenes.date-of-birth.feature
behind-the-scenes.feature
behind-the-scenes.investment-profile.feature
behind-the-scenes.life-expectancy.feature
behind-the-scenes.retirement-age.feature
behind-the-scenes.salary-indexation.feature
behind-the-scenes.voluntary-personal-contributions.feature
```

I would only get one json file called `behind-the-scenes.cucumber.json`, instead of one for each feature file.