### PR TITLE
fix(featuresLoader.js): Fix undefined variable `arguments`

### DIFF
--- a/lib/featuresLoader.js
+++ b/lib/featuresLoader.js
@@ -22,8 +22,6 @@ const createCucumber = (
     ${cucumberTemplate}
   window.cucumberJson = ${JSON.stringify(cucumberJson)};
 
-  var moduleCache = arguments[5];
-
   function clearFromCache(moduleId, instance){
     if(isWebpack()){
       delete require.cache[moduleId];
@@ -37,7 +35,9 @@ const createCucumber = (
   }
 
   // Stolen from https://github.com/browserify/browserify/issues/1444
-  function clearFromCacheBrowserify(instance) {
+  const clearFromCacheBrowserify = (instance) => {
+      var moduleCache = arguments[5];
+
       for(const key in moduleCache)
       {
           if(moduleCache[key].exports == instance)
@@ -47,7 +47,7 @@ const createCucumber = (
           }
       }
       throw new Error("could not clear instance from browserify module cache");
-  }
+  };
 
   ${globalToRequire.join("\n")}
 


### PR DESCRIPTION
Fixed by moving the variable `moduleCache = arguments[5]` inside function that uses it.

I ran into this error when upgrading Webpack and Cypress packages. Apparently, the `moduleCache` variable is not used `if(isWebpack())`, which is the case for me, so I moved the variable declaration inside the function `clearFromCacheBrowserify`, because that's where it's used. To make sure that `arugments` is not re-assigned by the `function`, I had to replace it with an arrow function.