### PR TITLE
fix: Rewrite of getStepDefinitionsPath function to fix issues with resolving step definition files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,10 +93,10 @@ Please make use of [cosmiconfig](https://github.com/davidtheclark/cosmiconfig) t
 
 Option | Default value | Description
 ------------ | ------------- | -------------
-commonPath | `cypress/integration/common` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false <br> `${nonGlobalStepBaseDir}/common` when `nonGlobalStepBaseDir` is defined | Define the path to a folder containing all common step definitions of your tests. When `nonGlobalStepBaseDir` is defined this path is defined from that base location. e.g `${nonGlobalStepBaseDir}/${commonPath}`.
+commonPath | `cypress/integration/common` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false <br> `${stepDefinitions}/common` when `stepDefinitions` is defined | Define the path to a folder containing all common step definitions of your tests. When `stepDefinitions` is defined this path is defined from that base location. e.g `${stepDefinitions}/${commonPath}`.
 nonGlobalStepDefinitions | false | If true use the Cypress Cucumber Preprocessor Style pattern for placing step definitions files. If false, we will use the "oldschool" (everything is global) Cucumber style.
-nonGlobalStepBaseDir| undefined | If defined and `nonGlobalStepDefinitions` is also true then step definition searches for folders with the features name will start from the directory provided here. The cwd is already taken into account. e.g `test/step_definitions`.
 stepDefinitions | `cypress/integration` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false | Path to the folder containing our step definitions.
+integrationFolder | same as stepDefinitions | Define this if you want to keep .feature files and steps definitions separate when using `nonGlobalStepDefinitions`.
 
 ## How to organize the tests
 

--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -9,30 +9,44 @@ const getStepDefinitionsPaths = (filePath) => {
   const appRoot = process.cwd();
   let paths = [];
   const config = getConfig();
-  if (config && config.nonGlobalStepDefinitions) {
-    let nonGlobalPath = getStepDefinitionPathsFrom(filePath);
-    let commonPath = config.commonPath || `${stepDefinitionPath()}/common/`;
+  let commonPath = `${stepDefinitionPath()}/common`;
+  const defaultGlobPattern = `${stepDefinitionPath()}/**/*.+(js|ts|tsx)`;
 
+  if (config) {
     if (config.commonPath) {
-      commonPath = path.resolve(appRoot, commonPath);
+      commonPath = path.resolve(stepDefinitionPath(), config.commonPath);
     }
+    const commonDefinitionsPattern = `${commonPath}/**/*.+(js|ts|tsx)`;
 
-    if (config.nonGlobalStepBaseDir) {
-      const stepBase = `${appRoot}/${config.nonGlobalStepBaseDir}`;
-      nonGlobalPath = nonGlobalPath.replace(stepDefinitionPath(), stepBase);
-      commonPath = `${stepBase}/${config.commonPath || "common/"}`;
+    if (config.nonGlobalStepDefinitions) {
+      let nonGlobalPath = getStepDefinitionPathsFrom(filePath);
+
+      if (config.integrationFolder) {
+        nonGlobalPath = nonGlobalPath.replace(
+          `${appRoot}/${config.integrationFolder}`,
+          stepDefinitionPath()
+        );
+      } else {
+        nonGlobalPath = `${stepDefinitionPath()}/${path.basename(
+          filePath,
+          path.extname(filePath)
+        )}`;
+      }
+
+      const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts|tsx)`;
+
+      paths = paths.concat(
+        glob.sync(nonGlobalPattern),
+        glob.sync(commonDefinitionsPattern)
+      );
+    } else {
+      paths = paths.concat(
+        glob.sync(commonDefinitionsPattern),
+        glob.sync(defaultGlobPattern)
+      );
     }
-
-    const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts|tsx)`;
-
-    const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts|tsx)`;
-    paths = paths.concat(
-      glob.sync(nonGlobalPattern),
-      glob.sync(commonDefinitionsPattern)
-    );
   } else {
-    const pattern = `${stepDefinitionPath()}/**/*.+(js|ts|tsx)`;
-    paths = paths.concat(glob.sync(pattern));
+    paths = paths.concat(glob.sync(defaultGlobPattern));
   }
   return paths;
 };

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -1,5 +1,4 @@
 /* eslint-disable global-require */
-jest.mock("./stepDefinitionPath.js", () => () => "stepDefinitionPath");
 jest.mock("glob", () => ({
   sync(pattern) {
     return pattern;
@@ -14,7 +13,19 @@ describe("getStepDefinitionsPaths", () => {
     ({ getConfig } = require("./getConfig"));
     jest.unmock("path");
     jest.mock("./getConfig");
+    jest.mock("./stepDefinitionPath.js", () => () => "cwd/stepDefinitionPath");
   });
+
+  it("should return defaults when config is missing completely", () => {
+    getConfig.mockReturnValue(undefined);
+
+    const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+
+    const actual = getStepDefinitionsPaths("/path");
+    const expected = "cwd/stepDefinitionPath/**/*.+(js|ts|tsx)";
+    expect(actual).to.include(expected);
+  });
+
   it("should return the default common folder", () => {
     getConfig.mockReturnValue({
       nonGlobalStepDefinitions: true,
@@ -23,12 +34,13 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 
     const actual = getStepDefinitionsPaths("/path");
-    const expected = "stepDefinitionPath/common/**/*.+(js|ts|tsx)";
+    const expected = "cwd/stepDefinitionPath/common/**/*.+(js|ts|tsx)";
     expect(actual).to.include(expected);
   });
 
   it("should return the common folder defined by the developer", () => {
     jest.mock("path", () => ({
+      ...jest.requireActual("path"),
       resolve(appRoot, commonPath) {
         return `./${appRoot}/${commonPath}`;
       },
@@ -41,15 +53,40 @@ describe("getStepDefinitionsPaths", () => {
 
     getConfig.mockReturnValue({
       nonGlobalStepDefinitions: true,
-      commonPath: "myPath/",
+      commonPath: "myPath",
     });
 
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
 
     const actual = getStepDefinitionsPaths("/path");
-    const expected = "./cwd/myPath/**/*.+(js|ts|tsx)";
+    const expected = "./cwd/stepDefinitionPath/myPath/**/*.+(js|ts|tsx)";
     expect(actual).to.include(expected);
   });
+
+  it("should return the common folder defined by the developer when nonGlobalStepDefinitions is false", () => {
+    jest.mock("path", () => ({
+      ...jest.requireActual("path"),
+      resolve(appRoot, commonPath) {
+        return `./${appRoot}/${commonPath}`;
+      },
+      extname() {
+        return ".js";
+      },
+    }));
+
+    jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
+
+    getConfig.mockReturnValue({
+      commonPath: "myPath",
+    });
+
+    const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+
+    const actual = getStepDefinitionsPaths("/path");
+    const expected = "./cwd/stepDefinitionPath/myPath/**/*.+(js|ts|tsx)";
+    expect(actual).to.include(expected);
+  });
+
   it("should return the default non global step definition pattern", () => {
     getConfig.mockReturnValue({
       nonGlobalStepDefinitions: true,
@@ -58,20 +95,23 @@ describe("getStepDefinitionsPaths", () => {
     const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
     const path = "stepDefinitionPath/test.feature";
     const actual = getStepDefinitionsPaths(path);
-    const expected = "stepDefinitionPath/test/**/*.+(js|ts|tsx)";
+    const expected = "cwd/stepDefinitionPath/test/**/*.+(js|ts|tsx)";
 
     expect(actual).to.include(expected);
   });
 
-  describe("nonGlobalStepBaseDir is defined", () => {
-    const path = "stepDefinitionPath/test.feature";
+  describe("stepDefinitions is defined", () => {
+    const path = "cwd/stepDefinitionPath/test.feature";
     const config = {
       nonGlobalStepDefinitions: true,
-      nonGlobalStepBaseDir: "nonGlobalStepBaseDir",
+      stepDefinitions: "nonGlobalStepBaseDir",
     };
 
     beforeEach(() => {
       jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
+      jest.mock("./stepDefinitionPath.js", () => () =>
+        "cwd/nonGlobalStepBaseDir"
+      );
     });
 
     it("should return the overriden non global step definition pattern and default common folder", () => {
@@ -88,12 +128,24 @@ describe("getStepDefinitionsPaths", () => {
       expect(actual).to.include(expectedNonGlobalDefinitionPattern);
       expect(actual).to.include(expectedCommonPath);
       expect(actual).to.not.include(
-        "stepDefinitionPath/test/**/*.+(js|ts|tsx)"
+        "cwd/stepDefinitionPath/test/**/*.+(js|ts|tsx)"
       );
     });
 
-    it("should return common folder defined by the dev and based on nonGlobalStepBaseDir", () => {
-      getConfig.mockReturnValue({ ...config, commonPath: "commonPath/" });
+    it("should return common folder defined by the dev and based on stepDefinitions", () => {
+      getConfig.mockReturnValue({ ...config, commonPath: "commonPath" });
+      jest.mock("./stepDefinitionPath.js", () => () =>
+        "cwd/nonGlobalStepBaseDir"
+      );
+      jest.mock("path", () => ({
+        ...jest.requireActual("path"),
+        resolve(appRoot, commonPath) {
+          return `${appRoot}/${commonPath}`;
+        },
+        extname() {
+          return ".js";
+        },
+      }));
 
       const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
       const actual = getStepDefinitionsPaths(path);
@@ -102,6 +154,73 @@ describe("getStepDefinitionsPaths", () => {
         "cwd/nonGlobalStepBaseDir/commonPath/**/*.+(js|ts|tsx)";
 
       expect(actual).to.include(expectedCommonPath);
+    });
+    describe("integrationFolder is defined", () => {
+      const pathWithIntegrationFolder = "cwd/integrationFolder/test.feature";
+      const configWithIntegrationFolder = {
+        nonGlobalStepDefinitions: true,
+        stepDefinitions: "nonGlobalStepBaseDir",
+        integrationFolder: "integrationFolder",
+      };
+
+      beforeEach(() => {
+        jest.spyOn(process, "cwd").mockImplementation(() => "cwd");
+        jest.mock("./stepDefinitionPath.js", () => () =>
+          "cwd/nonGlobalStepBaseDir"
+        );
+      });
+      it("should return steps folder defined by the dev and based on stepDefinitions and outside of the integrationFolder", () => {
+        getConfig.mockReturnValue(configWithIntegrationFolder);
+
+        const {
+          getStepDefinitionsPaths,
+        } = require("./getStepDefinitionsPaths");
+        const actual = getStepDefinitionsPaths(pathWithIntegrationFolder);
+
+        const expectedNonGlobalDefinitionPattern =
+          "cwd/nonGlobalStepBaseDir/test/**/*.+(js|ts|tsx)";
+
+        const expectedCommonPath =
+          "cwd/nonGlobalStepBaseDir/common/**/*.+(js|ts|tsx)";
+
+        expect(actual).to.include(expectedNonGlobalDefinitionPattern);
+        expect(actual).to.include(expectedCommonPath);
+        expect(actual).to.not.include(
+          "cwd/integrationFolder/test/**/*.+(js|ts|tsx)"
+        );
+      });
+
+      it("should return common folder defined by the dev and based on stepDefinitions and outside of the integrationFolder", () => {
+        getConfig.mockReturnValue({
+          ...configWithIntegrationFolder,
+          commonPath: "commonPath",
+        });
+        jest.mock("./stepDefinitionPath.js", () => () =>
+          "cwd/nonGlobalStepBaseDir"
+        );
+        jest.mock("path", () => ({
+          ...jest.requireActual("path"),
+          resolve(appRoot, commonPath) {
+            return `${appRoot}/${commonPath}`;
+          },
+          extname() {
+            return ".js";
+          },
+        }));
+
+        const {
+          getStepDefinitionsPaths,
+        } = require("./getStepDefinitionsPaths");
+        const actual = getStepDefinitionsPaths(pathWithIntegrationFolder);
+
+        const expectedCommonPath =
+          "cwd/nonGlobalStepBaseDir/commonPath/**/*.+(js|ts|tsx)";
+
+        expect(actual).to.include(expectedCommonPath);
+        expect(actual).to.not.include(
+          "cwd/integrationFolder/stepDefinitionPath/test/**/*.+(js|ts|tsx)"
+        );
+      });
     });
   });
 });

--- a/lib/stepDefinitionPath.js
+++ b/lib/stepDefinitionPath.js
@@ -13,7 +13,9 @@ module.exports = () => {
 
     if (config.nonGlobalStepDefinitions) {
       const relativePath =
-        confStepDefinitions || `cypress${path.sep}integration`;
+        confStepDefinitions ||
+        config.nonGlobalStepBaseDir || // nonGlobalStepBaseDir was made synonymous with stepDefinitions for backward compatibility
+        `cypress${path.sep}integration`;
       const stepsPath = path.resolve(appRoot, relativePath);
 
       if (!fs.existsSync(stepsPath)) {

--- a/lib/stepDefinitionPath.test.js
+++ b/lib/stepDefinitionPath.test.js
@@ -89,4 +89,15 @@ describe("load path from step definitions", () => {
       `${appRoot}${sep}e2e${sep}support${sep}step-definitions`
     );
   });
+  test("should allow the backward compatible use of nonGlobalStepBaseDir in cosmiconfig", () => {
+    const appRoot = process.cwd();
+    getConfig.mockReturnValue({
+      nonGlobalStepDefinitions: true,
+      nonGlobalStepBaseDir: "./e2e/support/step-definitions",
+    });
+    fs.existsSync.mockReturnValue(true);
+    expect(stepDefinitionPath()).to.equal(
+      `${appRoot}${sep}e2e${sep}support${sep}step-definitions`
+    );
+  });
 });


### PR DESCRIPTION
Rewrite of getStepDefinitionPaths function to fix various issues and inconsistencies with resolving
of step definition files from locations defined in config.

BREAKING CHANGE: Users that don't use any workarounds for this issue should be unaffected. But its
no longer possible to have stepDefinitions and nonGlobalStepBaseDir simultaneously defined in the
config since they are synonymous.

fix #329, fix #553

### Summary

1. Users will be able to define stepDefinitions folder and integrationFolder containing .feature files independently of each other.
To provide an example, this allows the following structure:
```
├── cypress-cucumber-preprocessor
│   ├── features
│   │   ├── backend
│   │   │   └── Testbackend.feature
│   │   └── frontend
│   │       └── Testui.feature
│   └── cypress
│       └── integration
│           ├── common
│           |   └── commonSteps.js
│           ├── backend
|           |   └── Testbackend
│           |        └── Testbackend.js
│           └── frontend
│               └── Testui
│                  └── Testui.js
```
Added flexibility should come in handy. 

2. I've also made stepDefinitions and nonGlobalStepBaseDir exchangeable (rationale for this decision provided in the side notes).  Option nonGlobalStepBaseDir is still handled just so this PR doesn't break existing configs but can be safely removed in the future.

3. As a side effect of this rewrite users can also define commonPath location when nonGlobalStepDefinitions which didn't seem to work.

### Sidenotes

1. I've decided to add another config option instead of relying on cypress configuration since while investigating this issue I've found a string of changes/PRs mentioning depreciation of using a similar approach in the past (0160151cd211aa72e8b726f77c8fd7e9928d1222)
3. My decision to merge stepDefinitions and nonGlobalStepBaseDir since as far as I could tell they were essentially meant to act the same way. I did some digging and came across this comment that reinforces my belief (https://github.com/TheBrainFamily/cypress-cucumber-preprocessor/pull/236#issuecomment-579207242). I can't think of any good reasons that they should be separated. 
2. Some of the existing tests had to be refactored.


