### PR TITLE
fix(createtestfromscenario): fix unique naming of scenarios derived from examples

### DIFF
--- a/cypress/integration/ScenarioOutline.feature
+++ b/cypress/integration/ScenarioOutline.feature
@@ -42,3 +42,17 @@ Feature: Being a plugin handling Scenario Outline
     Examples:
       | here |
       | abc  |
+
+  Scenario Outline: Multiple Examples for <var>
+    When I enter example <var>
+    Then I verify that example <var> is executed
+
+    Examples:
+      | var |
+      | "1" |
+      | "2" |
+
+    Examples:
+      | var |
+      | "3" |
+      | "4" |

--- a/cypress/support/step_definitions/backgroundSection.js
+++ b/cypress/support/step_definitions/backgroundSection.js
@@ -1,7 +1,7 @@
 /* global Given, Then */
 
 let counter = 0;
-console.log(window);
+
 Given("counter is incremented", () => {
   counter += 1;
 });

--- a/cypress/support/step_definitions/docString.js
+++ b/cypress/support/step_definitions/docString.js
@@ -5,8 +5,6 @@ let argString = "";
 // eslint-disable-next-line prefer-const
 let variableToVerify = ""; // we are assigning this through eval
 
-console.log(window);
-
 When("I use DocString for code like this:", (dataString) => {
   code = dataString;
 });

--- a/cypress/support/step_definitions/scenario_outline_multiple_examples.js
+++ b/cypress/support/step_definitions/scenario_outline_multiple_examples.js
@@ -1,0 +1,11 @@
+/* global Then, When */
+
+let var1 = "var1";
+
+When("I enter example {string}", (v1) => {
+  var1 = v1;
+});
+
+Then("I verify that example {string} is executed", (value) => {
+  expect(value).to.equal(var1);
+});

--- a/lib/createTestFromScenario.js
+++ b/lib/createTestFromScenario.js
@@ -8,8 +8,9 @@ const {
 } = require("./resolveStepDefinition");
 const { generateCucumberJson } = require("./cukejson/generateCucumberJson");
 const { shouldProceedCurrentStep, getEnvTags } = require("./tagsHelper");
+const { flattenArray } = require("./genericHelper");
 
-const replaceParameterTags = (rowData, text) =>
+const replaceParameterTags = (text, rowData) =>
   Object.keys(rowData).reduce(
     (value, key) => value.replace(new RegExp(`<${key}>`, "g"), rowData[key]),
     text
@@ -85,6 +86,48 @@ const writeCucumberJsonFile = (json) => {
   cy.writeFile(outFile, json, { log: false });
 };
 
+const convertExamplesToScenarios = (scenario) => {
+  let counter = 0;
+  const hasEnvTags = !!getEnvTags();
+
+  return flattenArray(
+    scenario.examples.map((example) => {
+      const exampleTags = [...example.tags, ...scenario.tags];
+
+      return example.tableBody
+        .map((row) => ({
+          rowLocation: row.location,
+          rowData: Object.fromEntries(
+            example.tableHeader.cells.map((header, headerIndex) => [
+              header.value,
+              row.cells[headerIndex].value,
+            ])
+          ),
+        }))
+        .map(({ rowLocation, rowData }) => {
+          counter += 1;
+          const scenarioName = replaceParameterTags(scenario.name, rowData);
+
+          return {
+            scenario: {
+              ...scenario,
+              name: `${scenarioName} (example #${counter})`,
+              example: rowLocation,
+              // tags on scenario's should be inherited by examples (https://cucumber.io/docs/cucumber/api/#tags)
+              tags: exampleTags,
+              shouldRun: !hasEnvTags || shouldProceedCurrentStep(exampleTags),
+            },
+            stepsToRun: scenario.steps.map((step) => ({
+              ...step,
+              text: replaceParameterTags(step.text, rowData),
+            })),
+            rowData,
+          };
+        });
+    })
+  );
+};
+
 const createTestFromScenarios = (
   allScenarios,
   backgroundSection,
@@ -107,59 +150,22 @@ const createTestFromScenarios = (
     Cypress.mocha.getRunner().on("fail", failHandler);
   });
 
-  allScenarios.forEach((section) => {
-    if (section.examples) {
-      const hasEnvTags = !!getEnvTags();
-      section.examples.forEach((example) => {
-        const exampleValues = [];
-        const exampleLocations = [];
-        const shouldRunExamples =
-          !hasEnvTags ||
-          shouldProceedCurrentStep(example.tags.concat(section.tags));
+  flattenArray(
+    allScenarios.map((scenario) =>
+      scenario.examples
+        ? convertExamplesToScenarios(scenario)
+        : {
+            scenario,
+            stepsToRun: scenario.steps,
+          }
+    )
+  ).forEach(({ scenario, stepsToRun, rowData }) => {
+    const stepsToRunWithBackground = [
+      ...((backgroundSection || {}).steps || []),
+      ...stepsToRun,
+    ];
 
-        example.tableBody.forEach((row, rowIndex) => {
-          exampleLocations[rowIndex] = row.location;
-          example.tableHeader.cells.forEach((header, headerIndex) => {
-            exampleValues[rowIndex] = {
-              ...exampleValues[rowIndex],
-              [header.value]: row.cells[headerIndex].value,
-            };
-          });
-        });
-
-        exampleValues.forEach((rowData, index) => {
-          // eslint-disable-next-line prefer-arrow-callback
-          const scenarioName = replaceParameterTags(rowData, section.name);
-          const uniqueScenarioName = `${scenarioName} (example #${index + 1})`;
-          const exampleSteps = section.steps.map((step) => {
-            const newStep = { ...step };
-            newStep.text = replaceParameterTags(rowData, newStep.text);
-            return newStep;
-          });
-
-          const stepsToRun = backgroundSection
-            ? backgroundSection.steps.concat(exampleSteps)
-            : exampleSteps;
-
-          const scenarioExample = {
-            ...section,
-            // tags on scenario's should be inherited by examples (https://cucumber.io/docs/cucumber/api/#tags)
-            tags: example.tags.concat(section.tags),
-            shouldRun: shouldRunExamples,
-            name: uniqueScenarioName,
-            example: exampleLocations[index],
-          };
-
-          runTest.call(this, scenarioExample, stepsToRun, rowData);
-        });
-      });
-    } else {
-      const stepsToRun = backgroundSection
-        ? backgroundSection.steps.concat(section.steps)
-        : section.steps;
-
-      runTest.call(this, section, stepsToRun);
-    }
+    runTest.call(this, scenario, stepsToRunWithBackground, rowData);
   });
 
   // eslint-disable-next-line func-names, prefer-arrow-callback
@@ -188,4 +194,5 @@ const createTestFromScenarios = (
 
 module.exports = {
   createTestFromScenarios,
+  convertExamplesToScenarios,
 };

--- a/lib/createTestFromScenario.test.js
+++ b/lib/createTestFromScenario.test.js
@@ -1,0 +1,103 @@
+const { expect } = require("chai");
+const { convertExamplesToScenarios } = require("./createTestFromScenario");
+const { flattenArray } = require("./genericHelper");
+
+describe("convertExamplesToScenarios", () => {
+  const OLD_ENV = process.env;
+  const OLD_CYPRESS = window.Cypress;
+
+  beforeEach(() => {
+    process.env = { ...OLD_ENV };
+    window.Cypress = {
+      ...window.Cypress,
+      env: (varname) => process.env[varname],
+    };
+  });
+
+  afterEach(() => {
+    process.env = OLD_ENV;
+    window.Cypress = OLD_CYPRESS;
+  });
+
+  const getTestScenarioOutline = () => ({
+    name: "Multiple Examples for <var>",
+    tags: [],
+    steps: [
+      { text: "I enter example <var>" },
+      { text: "I verify that example <var> is executed" },
+    ],
+    examples: [
+      {
+        tableHeader: {
+          cells: [{ value: "var" }],
+        },
+        tableBody: [
+          {
+            location: 11,
+            cells: [{ value: "aaa" }],
+          },
+          {
+            location: 12,
+            cells: [{ value: "bbb" }],
+          },
+        ],
+        tags: [],
+      },
+      {
+        tableHeader: {
+          cells: [{ value: "var" }],
+        },
+        tableBody: [
+          {
+            location: 21,
+            cells: [{ value: "ccc" }],
+          },
+          {
+            location: 22,
+            cells: [{ value: "ddd" }],
+          },
+        ],
+        tags: [],
+      },
+    ],
+  });
+
+  it("names scenarios uniquely", () => {
+    // Given
+    const scenarioOutline = getTestScenarioOutline();
+
+    // When
+    const results = convertExamplesToScenarios(scenarioOutline);
+
+    // Then
+    expect(results.map((result) => result.scenario.name)).to.eql(
+      results.map(
+        (scenario, index) =>
+          `Multiple Examples for ${
+            flattenArray(
+              scenarioOutline.examples.map((example) => example.tableBody)
+            )[index].cells[0].value
+          } (example #${index + 1})`
+      )
+    );
+  });
+
+  it("skips examples with non-matching tags", () => {
+    // Given
+    process.env.TAGS = "@test-tag";
+
+    const scenarioOutline = getTestScenarioOutline();
+    scenarioOutline.examples[0].tags = [{ name: "@test-tag" }];
+
+    // When
+    const results = convertExamplesToScenarios(scenarioOutline);
+
+    // Then
+    expect(results.map((result) => result.scenario.shouldRun)).to.eql([
+      true,
+      true,
+      false,
+      false,
+    ]);
+  });
+});

--- a/lib/createTestFromScenario.test.js
+++ b/lib/createTestFromScenario.test.js
@@ -71,13 +71,13 @@ describe("convertExamplesToScenarios", () => {
 
     // Then
     expect(results.map((result) => result.scenario.name)).to.eql(
-      results.map(
-        (scenario, index) =>
-          `Multiple Examples for ${
-            flattenArray(
-              scenarioOutline.examples.map((example) => example.tableBody)
-            )[index].cells[0].value
-          } (example #${index + 1})`
+      flattenArray(
+        scenarioOutline.examples.map((example) => example.tableBody)
+      ).map(
+        (exampleRow, index) =>
+          `Multiple Examples for ${exampleRow.cells[0].value} (example #${
+            index + 1
+          })`
       )
     );
   });

--- a/lib/genericHelper.js
+++ b/lib/genericHelper.js
@@ -1,0 +1,6 @@
+// Replace with "Array.prototype.flat()" once all browsers fully support it.
+const flattenArray = (arr) => [].concat(...arr);
+
+module.exports = {
+  flattenArray,
+};

--- a/lib/genericHelper.test.js
+++ b/lib/genericHelper.test.js
@@ -1,0 +1,20 @@
+const { flattenArray } = require("./genericHelper");
+
+describe("flattenArray", () => {
+  it("flattens arrays with a depth of 1", () => {
+    expect(
+      flattenArray([
+        null,
+        { value: "a" },
+        [{ value: "b" }, { value: "c" }],
+        [[{ value: "d" }]],
+      ])
+    ).to.eql([
+      null,
+      { value: "a" },
+      { value: "b" },
+      { value: "c" },
+      [{ value: "d" }],
+    ]);
+  });
+});

--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -91,7 +91,7 @@ function applyExampleData(argument, exampleRowData, replaceParameterTags) {
       const cells = {
         cells: tr.cells.map((c) => {
           const value = {
-            value: replaceParameterTags(exampleRowData, c.value),
+            value: replaceParameterTags(c.value, exampleRowData),
           };
           return { ...c, ...value };
         }),
@@ -120,7 +120,7 @@ function resolveStepArgument(argument, exampleRowData, replaceParameterTags) {
   }
   if (argument.type === "DocString") {
     if (exampleRowData) {
-      return replaceParameterTags(exampleRowData, argument.content);
+      return replaceParameterTags(argument.content, exampleRowData);
     }
     return argument.content;
   }

--- a/lib/resolveStepDefinition.test.js
+++ b/lib/resolveStepDefinition.test.js
@@ -9,6 +9,7 @@ describe("Scenario Outline", () => {
   require("../cypress/support/step_definitions/scenario_outline_string");
   require("../cypress/support/step_definitions/scenario_outline_data_table");
   require("../cypress/support/step_definitions/scenario_outline_multiple_vars");
+  require("../cypress/support/step_definitions/scenario_outline_multiple_examples");
   resolveFeatureFromFile("./cypress/integration/ScenarioOutline.feature");
 });
 


### PR DESCRIPTION
When multiple 'Examples:' tables are given, the counter just resets to 1. This change fixes this
behavior so that all examples are unique.