### PR TITLE
feat(cypress-tags.js): provide cypress-executable through cypress.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,14 @@ Please note - we use our own cypress-tags wrapper to speed things up.
 This wrapper calls the cypress executable from local modules and if not found it falls back to the globally installed one.
 For more details and examples please take a look to the [example repo](https://github.com/TheBrainFamily/cypress-cucumber-example).
 
+In case you want to change the cypress-executable to a different one you can define it in the cypress.json as follows:
+
+```javascript
+{
+  "cypressExecutable": "path/to/cypress/executable"
+}
+```
+
 ### Ignoring specific scenarios using tags when executing test runner
 
 You can also use tags to skip or ignore specific tests/scenarios when running cypress test runner (where you don't have the abilitiy to pass parameters like in the examples above for the execution)

--- a/cypress-tags.js
+++ b/cypress-tags.js
@@ -24,6 +24,7 @@ const envTags = parseArgsOrDefault("TAGS", "");
 let specGlob = envGlob || "cypress/integration/**/*.feature";
 let ignoreGlob = "";
 let usingCypressConf = false;
+let cypressExecutable;
 
 if (!envGlob) {
   try {
@@ -53,6 +54,10 @@ if (!envGlob) {
     console.log("Using cypress.json configuration:");
     console.log("Spec files: ", specGlob);
     if (ignoreGlob) console.log("Ignored files: ", ignoreGlob);
+
+    if (cypressConf && cypressConf.cypressExecutable) {
+      cypressExecutable = cypressConf.cypressExecutable;
+    }
   } catch (err) {
     usingCypressConf = false;
     specGlob = "cypress/integration/**/*.feature";
@@ -103,7 +108,11 @@ function getOsSpecificExecutable(command) {
 }
 
 function getCypressExecutable() {
-  const command = getOsSpecificExecutable(`${__dirname}/../.bin/cypress`);
+  // check, if path to cypress-executable has been provided through cypress.json.
+  let command = cypressExecutable;
+  if (!command || !fs.existsSync(command)) {
+    command = getOsSpecificExecutable(`${__dirname}/../.bin/cypress`);
+  }
   // fallback to the globally installed cypress instead
   return fs.existsSync(command) ? command : getOsSpecificExecutable("cypress");
 }


### PR DESCRIPTION
As sometimes it might be necessary to provide a wrapper for cypress (see https://github.com/sorry-cypress/cy2) there should also be a possibility to divert from the fixed usage of the cypress-executable. To do so an easy approach would be to check for the entry `cypressExecutable` in the cypress.json. If this is set, it is used instead the default cypress-executable.