### PR TITLE
feat(step code dir): add option to search for step code relative from the feature file

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Option | Default value | Description
 commonPath | `cypress/integration/common` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false <br> `${nonGlobalStepBaseDir}/common` when `nonGlobalStepBaseDir` is defined | Define the path to a folder containing all common step definitions of your tests. When `nonGlobalStepBaseDir` is defined this path is defined from that base location. e.g `${nonGlobalStepBaseDir}/${commonPath}`.
 nonGlobalStepDefinitions | false | If true use the Cypress Cucumber Preprocessor Style pattern for placing step definitions files. If false, we will use the "oldschool" (everything is global) Cucumber style.
 nonGlobalStepBaseDir| undefined | If defined and `nonGlobalStepDefinitions` is also true then step definition searches for folders with the features name will start from the directory provided here. The cwd is already taken into account. e.g `test/step_definitions`.
+nonGlobalStepRelativeDir | undefined | If defined and `nonGlobalStepDefinitions` is also true then step definition searches for folders with the feature's name from the directory provided here relative to the feature file.
 stepDefinitions | `cypress/integration` when `nonGlobalStepDefinitions` is true <br> `cypress/support/step_definitions` when `nonGlobalStepDefinitions` is false | Path to the folder containing our step definitions.
 
 ## How to organize the tests

--- a/lib/getStepDefinitionsPaths.js
+++ b/lib/getStepDefinitionsPaths.js
@@ -23,6 +23,20 @@ const getStepDefinitionsPaths = (filePath) => {
       commonPath = `${stepBase}/${config.commonPath || "common/"}`;
     }
 
+    if (config.nonGlobalStepRelativeDir) {
+      const filePathSegments = filePath.split(path.sep);
+      const [fileName] = filePathSegments.slice(-1);
+      const fileNameWithoutExt = fileName.replace(path.extname(fileName), "");
+      const pathUntilFeature = filePathSegments.slice(0, -1).join(path.sep);
+      const testCodePath = path.join(
+        pathUntilFeature,
+        config.nonGlobalStepRelativeDir
+      );
+
+      nonGlobalPath = path.join(testCodePath, fileNameWithoutExt);
+      commonPath = path.join(testCodePath, config.commonPath || "common/");
+    }
+
     const nonGlobalPattern = `${nonGlobalPath}/**/*.+(js|ts|tsx)`;
 
     const commonDefinitionsPattern = `${commonPath}**/*.+(js|ts|tsx)`;

--- a/lib/getStepDefinitionsPaths.test.js
+++ b/lib/getStepDefinitionsPaths.test.js
@@ -96,4 +96,42 @@ describe("getStepDefinitionsPaths", () => {
       expect(actual).to.include(expectedCommonPath);
     });
   });
+
+  describe("nonGlobalStepRelativeDir is defined", () => {
+    const path = "stepDefinitionPath/nextLevel/test.feature";
+    const config = {
+      nonGlobalStepDefinitions: true,
+      nonGlobalStepRelativeDir: "../foobar",
+    };
+
+    it("should return the overriden non global step definition pattern and default common folder", () => {
+      getConfig.mockReturnValue(config);
+
+      const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+      const actual = getStepDefinitionsPaths(path);
+
+      const expectedNonGlobalDefinitionPattern =
+        "stepDefinitionPath/foobar/test/**/*.+(js|ts|tsx)";
+      const expectedCommonPath =
+        "stepDefinitionPath/foobar/common/**/*.+(js|ts|tsx)";
+
+      expect(actual).to.include(expectedNonGlobalDefinitionPattern);
+      expect(actual).to.include(expectedCommonPath);
+      expect(actual).to.not.include(
+        "stepDefinitionPath/test/**/*.+(js|ts|tsx)"
+      );
+    });
+
+    it("should return common folder defined by the dev and based on nonGlobalStepBaseDir", () => {
+      getConfig.mockReturnValue({ ...config, commonPath: "commonPath/" });
+
+      const { getStepDefinitionsPaths } = require("./getStepDefinitionsPaths");
+      const actual = getStepDefinitionsPaths(path);
+
+      const expectedCommonPath =
+        "stepDefinitionPath/foobar/commonPath/**/*.+(js|ts|tsx)";
+
+      expect(actual).to.include(expectedCommonPath);
+    });
+  });
 });


### PR DESCRIPTION
- [x] Feature
- [x] Docs (readme)
- [x] tests (jest)

### Background

We're maintaining a component library where each component it is own (yarn) workspace.
That means that we have a slightly different architecture and feature files split across the project:

```
|-- component 1
|---- features/
|-- component 2
|---- features/
|-- component 3
|---- features/
```

This works already :tada: But we'd like to keep the features separate from the test code as they should be independent from the technical implementation, so our goal is to have the following structure:


```
|-- component 1
|---- features/
|------ a.feature
|---- e2e/
|------ a/index.js
|-- component 2
|---- features/
|------ b.feature
|---- e2e/
|------ b/index.js
|-- component 3
|---- features/
|------ c.feature
|---- e2e/
|------ c/index.js
```

This does not work with the `nonGlobalStepBaseDir` flag as we have multiple locations with test code.

### Feature: New option `nonGlobalStepRelativeDir`

I've added an additional option which can be used to define the location of the test code of the step definitions relative to the location of the feature file:

```
{
    "nonGlobalStepDefinitions": true,
    "nonGlobalStepRelativeDir": "../e2e"
}