### PR TITLE
fix: throw error if ambiguous step definition implementation found

### DIFF
--- a/lib/resolveStepDefinition.js
+++ b/lib/resolveStepDefinition.js
@@ -49,13 +49,21 @@ class StepDefinitionRegistry {
       });
     };
 
-    this.resolve = (type, text, runningFeatureName) =>
-      this.definitions.filter(
+    this.resolve = (type, text, runningFeatureName) => {
+      const matchedStepImplementations = this.definitions.filter(
         ({ expression, featureName }) =>
           expression.match(text) &&
           (runningFeatureName === featureName ||
             featureName === "___GLOBAL_EXECUTION___")
-      )[0];
+      );
+
+      if (matchedStepImplementations.length > 1) {
+        throw new Error(
+          `Ambiguous step definitions detected for text: ${text}. \n Please check and remove ambiguous implementations`
+        );
+      }
+      return matchedStepImplementations[0];
+    };
   }
 }
 


### PR DESCRIPTION
Proposed fix for issue #678.

I tried to use commitizen not sure if it went through correctly. Also not super experienced with JS unit tests so not sure what is needed there. Any advice much appreciated. 

@badeball @lgandecki 