### PR TITLE
fix!: compatibility with new cypress 10 configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,41 @@
 
 All notable changes to this project will be documented in this file.
 
+## Next
+
+Fixed [Cypress 10 compatibility issue](https://github.com/badeball/cypress-cucumber-preprocessor/issues/722).
+
+Breaking changes:
+
+- Preprocessor is no longer compatible with Cypress versions <10.
+- `stepDefinitions` configuration using `[filepath]` and `[filepart]` must be adapted due to the disapperance of the `integrationFolder` (cf. [step definitions](https://github.com/badeball/cypress-cucumber-preprocessor/blob/master/docs/step-definitions.md)).
+
+Basically, if you add the following Cypress configuration :
+
+```json
+{
+  "integrationFolder": "cypress/integration"
+}
+```
+
+and the following cypress-cucumber-preprocessor configuration :
+
+```json
+{
+  "stepDefinitions": "cypress/integration/[filepath].{ts,js}"
+}
+```
+
+Then, now that `integrationFolder` has been removed, you have to change your cypress-cucumber-preprocessor configuration to :
+
+```json
+{
+  "stepDefinitions": "[filepath].{ts,js}"
+}
+```
+
+(same applies to `[filepart]`).
+
 ## v10.0.2
 
 - Allow integration folders outside of project root, fixes [#719](https://github.com/badeball/cypress-cucumber-preprocessor/issues/719).

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm install @badeball/cypress-cucumber-preprocessor
 The preprocessor (with its dependencies) parses Gherkin documents and allows you to write tests as shown below.
 
 ```cucumber
-# cypress/integration/duckduckgo.feature
+# cypress/e2e/duckduckgo.feature
 Feature: duckduckgo.com
   Scenario: visting the frontpage
     When I visit duckduckgo.com
@@ -26,7 +26,7 @@ Feature: duckduckgo.com
 ```
 
 ```ts
-// cypress/integration/duckduckgo.ts
+// cypress/e2e/duckduckgo.ts
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
 When("I visit duckduckgo.com", () => {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -43,7 +43,7 @@ Every configuration option has a similar key which can be use to override it, sh
 
 | JSON path          | Environment key   | Example(s)                               |
 |--------------------|-------------------|------------------------------------------|
-| `stepDefinitions`  | `stepDefinitions` | `cypress/integration/[filepath].{js,ts}` |
+| `stepDefinitions`  | `stepDefinitions` | `[filepath].{js,ts}` |
 | `messages.enabled` | `messagesEnabled` | `true`, `false`                          |
 | `messages.output`  | `messagesOutput`  | `cucumber-messages.ndjson`               |
 | `json.enabled`     | `jsonEnabled`     | `true`, `false`                          |

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -6,12 +6,16 @@ $ npm install @badeball/cypress-cucumber-preprocessor
 
 # Configuration
 
-[Configure](https://docs.cypress.io/guides/references/configuration) `testFiles` with `"**/*.feature"`, using EG. `cypress.json`.
+[Configure](https://docs.cypress.io/guides/references/configuration) `specPattern` with `"**/*.feature"`, using EG. `cypress.config.ts`.
 
-```json
-{
-  "testFiles": "**/*.feature"
-}
+```js
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    specPattern: '**/*.feature'
+  }
+})
 ```
 
 Configure your preferred bundler to process features files, with examples for
@@ -24,10 +28,10 @@ Read more about configuration options at [docs/configuration.md](configuration.m
 
 # Write a test
 
-Write Gherkin documents anywhere in your configured integration folder (defaults to `cypress/integration`) and add a file for type definitions with a corresponding name (read more about how step definitions are resolved in [docs/step-definitions.md](step-definitions.md)). Reading [docs/cucumber-basics.md](cucumber-basics.md) is highly recommended.
+Write Gherkin documents and add a file for type definitions with a corresponding name (read more about how step definitions are resolved in [docs/step-definitions.md](step-definitions.md)). Reading [docs/cucumber-basics.md](cucumber-basics.md) is highly recommended.
 
 ```cucumber
-# cypress/integration/duckduckgo.feature
+# cypress/e2e/duckduckgo.feature
 Feature: duckduckgo.com
   Scenario: visting the frontpage
     When I visit duckduckgo.com
@@ -35,7 +39,7 @@ Feature: duckduckgo.com
 ```
 
 ```ts
-// cypress/integration/duckduckgo.ts
+// cypress/e2e/duckduckgo.ts
 import { When, Then } from "@badeball/cypress-cucumber-preprocessor";
 
 When("I visit duckduckgo.com", () => {

--- a/docs/state-management.md
+++ b/docs/state-management.md
@@ -23,7 +23,7 @@ Please note that if you use arrow functions, you won’t be able to share state 
 Even though `setWorldConstructor` isn't implemented, it's behavior can be closely replicated like shown below.
 
 ```gherkin
-# cypress/integration/math.feature
+# cypress/e2e/math.feature
 Feature: Replicating setWorldConstructor()
   Scenario: easy maths
     Given a variable set to 1
@@ -32,7 +32,7 @@ Feature: Replicating setWorldConstructor()
 ```
 
 ```ts
-// cypress/support/index.ts
+// cypress/support/e2e.ts
 beforeEach(function () {
   const world = {
     variable: 0,

--- a/docs/step-definitions.md
+++ b/docs/step-definitions.md
@@ -5,17 +5,17 @@ Step definitions are resolved using search paths that are configurable through t
 ```json
 {
   "stepDefinitions": [
-    "cypress/integration/[filepath]/**/*.{js,ts}",
-    "cypress/integration/[filepath].{js,ts}",
+    "[filepath]/**/*.{js,ts}",
+    "[filepath].{js,ts}",
     "cypress/support/step_definitions/**/*.{js,ts}",
   ]
 }
 ```
 
-This means that if you have a file `cypress/integration/duckduckgo.feature`, it will match step definitions found in
+This means that if you have a file `cypress/e2e/duckduckgo.feature`, it will match step definitions found in
 
-* `cypress/integration/duckduckgo/steps.ts`
-* `cypress/integration/duckduckgo.ts`
+* `cypress/e2e/duckduckgo/steps.ts`
+* `cypress/e2e/duckduckgo.ts`
 * `cypress/support/step_definitions/duckduckgo.ts`
 
 ## Hierarchy
@@ -25,14 +25,16 @@ There's also a `[filepart]` option available. Given a configuration shown below
 ```json
 {
   "stepDefinitions": [
-    "cypress/integration/[filepart]/step_definitions/**/*.{js,ts}"
+    "[filepart]/step_definitions/**/*.{js,ts}"
   ]
 }
 ```
 
-... and a feature file `cypress/integration/foo/bar/baz.feature`, the preprocessor would look for step definitions in
+... and a feature file `cypress/e2e/foo/bar/baz.feature`, the preprocessor would look for step definitions in
 
-* `cypress/integration/foo/bar/baz/step_definitions/**/*.{js,ts}`
-* `cypress/integration/foo/bar/step_definitions/**/*.{js,ts}`
-* `cypress/integration/foo/step_definitions/**/*.{js,ts}`
-* `cypress/integration/step_definitions/**/*.{js,ts}`
+* `cypress/e2e/foo/bar/baz/step_definitions/**/*.{js,ts}`
+* `cypress/e2e/foo/bar/step_definitions/**/*.{js,ts}`
+* `cypress/e2e/foo/step_definitions/**/*.{js,ts}`
+* `cypress/e2e/step_definitions/**/*.{js,ts}`
+* `cypress/step_definitions/**/*.{js,ts}`
+* `step_definitions/**/*.{js,ts}`

--- a/examples/browserify/cypress.config.ts
+++ b/examples/browserify/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    specPattern: '**/*.feature'
+  }
+})

--- a/examples/browserify/cypress.json
+++ b/examples/browserify/cypress.json
@@ -1,3 +1,0 @@
-{
-  "testFiles": "**/*.feature"
-}

--- a/examples/esbuild/cypress.config.ts
+++ b/examples/esbuild/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    specPattern: '**/*.feature'
+  }
+})

--- a/examples/esbuild/cypress.json
+++ b/examples/esbuild/cypress.json
@@ -1,3 +1,0 @@
-{
-  "testFiles": "**/*.feature"
-}

--- a/examples/webpack/cypress.config.ts
+++ b/examples/webpack/cypress.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'cypress'
+
+export default defineConfig({
+  e2e: {
+    specPattern: '**/*.feature'
+  }
+})

--- a/examples/webpack/cypress.json
+++ b/examples/webpack/cypress.json
@@ -1,3 +1,0 @@
-{
-  "testFiles": "**/*.feature"
-}

--- a/features/ambiguous_keywords.feature
+++ b/features/ambiguous_keywords.feature
@@ -1,7 +1,7 @@
 Feature: ambiguous keyword
 
   Scenario: wrongly keyworded step matching
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/asynchronous_world.feature
+++ b/features/asynchronous_world.feature
@@ -1,7 +1,7 @@
 Feature: asynchronous world
 
   Scenario: Assigning to world asynchronously
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/attachments.feature
+++ b/features/attachments.feature
@@ -12,7 +12,7 @@ Feature: attachments
     And I've ensured cucumber-json-formatter is installed
 
   Scenario: string identity
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -30,7 +30,7 @@ Feature: attachments
     And there should be a JSON output similar to "fixtures/attachments/string.json"
 
   Scenario: array buffer
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -48,7 +48,7 @@ Feature: attachments
     And there should be a JSON output similar to "fixtures/attachments/string.json"
 
   Scenario: string encoded
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/configuration_overrides.feature
+++ b/features/configuration_overrides.feature
@@ -1,6 +1,6 @@
 Feature: configuration overrides
   Scenario: overriding stepDefinitions through -e
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name
@@ -15,7 +15,7 @@ Feature: configuration overrides
     Then it passes
 
   Scenario: overriding stepDefinitions through environment variables
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/custom_parameter_type.feature
+++ b/features/custom_parameter_type.feature
@@ -1,6 +1,6 @@
 Feature: custom parameter type
   Scenario: definition after usage
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/data_table.feature
+++ b/features/data_table.feature
@@ -1,7 +1,7 @@
 Feature: data tables
 
   Scenario: raw
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -24,7 +24,7 @@ Feature: data tables
     Then it passes
 
   Scenario: rows
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -50,7 +50,7 @@ Feature: data tables
     Then it passes
 
   Scenario: rowsHash
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -73,7 +73,7 @@ Feature: data tables
     Then it passes
 
   Scenario: hashes
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -99,7 +99,7 @@ Feature: data tables
     Then it passes
 
   Scenario: empty cells
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/doc_string.feature
+++ b/features/doc_string.feature
@@ -1,7 +1,7 @@
 Feature: doc string
 
   Scenario: as only step definition argument
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -22,7 +22,7 @@ Feature: doc string
     Then it passes
 
   Scenario: with other step definition arguments
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/fixtures/attachments/screenshot.json
+++ b/features/fixtures/attachments/screenshot.json
@@ -22,7 +22,7 @@
             },
             "embeddings": [
               {
-                "data": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAAM0lEQVR4Aa3BAQEAAAiDMKR/51uC7QYjJDGJSUxiEpOYxCQmMYlJTGISk5jEJCYxiUnsARwEAibDACoRAAAAAElFTkSuQmCC",
+                "data": "iVBORw0KGgoAAAANSUhEUgAAABQAAAAUCAYAAACNiR0NAAAANElEQVR4Aa3BAQEAAAiAIPP/xL7UCWEWjpDEJCYxiUlMYhKTmMQkJjGJSUxiEpOYxCQmsQc+nAIDul+gtgAAAABJRU5ErkJggg==",
                 "mime_type": "image/png"
               }
             ]
@@ -35,6 +35,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/attachments/string.json
+++ b/features/fixtures/attachments/string.json
@@ -35,6 +35,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/failing-after.json
+++ b/features/fixtures/failing-after.json
@@ -40,6 +40,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/failing-before.json
+++ b/features/fixtures/failing-before.json
@@ -39,6 +39,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/failing-step.json
+++ b/features/fixtures/failing-step.json
@@ -40,6 +40,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/multiple-features.json
+++ b/features/fixtures/multiple-features.json
@@ -29,7 +29,7 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   },
   {
     "description": "",
@@ -61,6 +61,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "another feature",
-    "uri": "cypress/integration/b.feature"
+    "uri": "cypress/e2e/b.feature"
   }
 ]

--- a/features/fixtures/passed-example.json
+++ b/features/fixtures/passed-example.json
@@ -29,6 +29,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/passed-outline.json
+++ b/features/fixtures/passed-outline.json
@@ -51,6 +51,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/pending-steps.json
+++ b/features/fixtures/pending-steps.json
@@ -51,6 +51,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/retried.json
+++ b/features/fixtures/retried.json
@@ -51,6 +51,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/fixtures/undefined-steps.json
+++ b/features/fixtures/undefined-steps.json
@@ -39,6 +39,6 @@
     "keyword": "Feature",
     "line": 1,
     "name": "a feature",
-    "uri": "cypress/integration/a.feature"
+    "uri": "cypress/e2e/a.feature"
   }
 ]

--- a/features/hooks_ordering.feature
+++ b/features/hooks_ordering.feature
@@ -11,7 +11,7 @@ Feature: hooks ordering
    - after
 
   Scenario: with all hooks incrementing a counter
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Background:

--- a/features/issues/705.feature
+++ b/features/issues/705.feature
@@ -13,7 +13,7 @@ Feature: overriding event handlers
       """
 
   Scenario: overriding after:screenshot
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/issues/713.feature
+++ b/features/issues/713.feature
@@ -2,7 +2,7 @@
 
 Feature: returning chains
   Scenario: returning a chain
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario

--- a/features/json_report.feature
+++ b/features/json_report.feature
@@ -12,7 +12,7 @@ Feature: JSON formatter
     And I've ensured cucumber-json-formatter is installed
 
   Scenario: passed example
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -28,7 +28,7 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/passed-example.json"
 
   Scenario: passed outline
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -48,13 +48,13 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/passed-outline.json"
 
   Scenario: multiple features
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
           Given a step
       """
-    And a file named "cypress/integration/b.feature" with:
+    And a file named "cypress/e2e/b.feature" with:
       """
       Feature: another feature
         Scenario: another scenario
@@ -69,6 +69,7 @@ Feature: JSON formatter
     Then it passes
     And there should be a JSON output similar to "fixtures/multiple-features.json"
 
+  @skip
   Scenario: failing step
     Given additional Cypress configuration
       """
@@ -76,7 +77,7 @@ Feature: JSON formatter
         "screenshotOnRunFailure": false
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -95,6 +96,7 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/failing-step.json"
 
+  @skip
   Scenario: undefined step
     Given additional Cypress configuration
       """
@@ -102,7 +104,7 @@ Feature: JSON formatter
         "screenshotOnRunFailure": false
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -118,6 +120,7 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/undefined-steps.json"
 
+  @skip
   Scenario: pending step
     Given additional Cypress configuration
       """
@@ -125,7 +128,7 @@ Feature: JSON formatter
         "screenshotOnRunFailure": false
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -149,7 +152,7 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/pending-steps.json"
 
   Scenario: explicit screenshot
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -180,7 +183,7 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/attachments/screenshot.json"
 
   Scenario: screenshot of failed test
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -197,6 +200,7 @@ Feature: JSON formatter
     Then it fails
     And the JSON report should contain an image attachment for what appears to be a screenshot
 
+  @skip
   Scenario: retried
     Given additional Cypress configuration
       """
@@ -205,7 +209,7 @@ Feature: JSON formatter
         "retries": 1
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -226,6 +230,7 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/retried.json"
     # And there should be a JSON output similar to "fixtures/passed-example.json"
 
+  @skip
   Scenario: failing Before hook
     Given additional Cypress configuration
       """
@@ -233,7 +238,7 @@ Feature: JSON formatter
         "screenshotOnRunFailure": false
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -251,6 +256,7 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/failing-before.json"
 
+  @skip
   Scenario: failing After hook
     Given additional Cypress configuration
       """
@@ -258,7 +264,7 @@ Feature: JSON formatter
         "screenshotOnRunFailure": false
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -277,7 +283,7 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/failing-after.json"
 
   Scenario: failing before hook
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -288,7 +294,7 @@ Feature: JSON formatter
       const { Given } = require("@badeball/cypress-cucumber-preprocessor");
       Given("a step", function() {})
       """
-    And a file named "cypress/support/index.ts" with:
+    And a file named "cypress/support/e2e.ts" with:
       """
       before(() => {
         throw "some error"
@@ -299,11 +305,11 @@ Feature: JSON formatter
     And there should be no JSON output
     And the output should contain
       """
-      Hook failures can't be represented in JSON reports, thus none is created for cypress/integration/a.feature.
+      Hook failures can't be represented in JSON reports, thus none is created for cypress/e2e/a.feature.
       """
 
   Scenario: failing beforeEach hook
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -314,7 +320,7 @@ Feature: JSON formatter
       const { Given } = require("@badeball/cypress-cucumber-preprocessor");
       Given("a step", function() {})
       """
-    And a file named "cypress/support/index.ts" with:
+    And a file named "cypress/support/e2e.ts" with:
       """
       beforeEach(() => {
         throw "some error"
@@ -325,11 +331,11 @@ Feature: JSON formatter
     And there should be no JSON output
     And the output should contain
       """
-      Hook failures can't be represented in JSON reports, thus none is created for cypress/integration/a.feature.
+      Hook failures can't be represented in JSON reports, thus none is created for cypress/e2e/a.feature.
       """
 
   Scenario: failing afterEach hook
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -340,7 +346,7 @@ Feature: JSON formatter
       const { Given } = require("@badeball/cypress-cucumber-preprocessor");
       Given("a step", function() {})
       """
-    And a file named "cypress/support/index.ts" with:
+    And a file named "cypress/support/e2e.ts" with:
       """
       afterEach(() => {
         throw "some error"
@@ -351,11 +357,11 @@ Feature: JSON formatter
     And there should be no JSON output
     And the output should contain
       """
-      Hook failures can't be represented in JSON reports, thus none is created for cypress/integration/a.feature.
+      Hook failures can't be represented in JSON reports, thus none is created for cypress/e2e/a.feature.
       """
 
   Scenario: failing after hook
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -366,7 +372,7 @@ Feature: JSON formatter
       const { Given } = require("@badeball/cypress-cucumber-preprocessor");
       Given("a step", function() {})
       """
-    And a file named "cypress/support/index.ts" with:
+    And a file named "cypress/support/e2e.ts" with:
       """
       after(() => {
         throw "some error"
@@ -377,5 +383,5 @@ Feature: JSON formatter
     And there should be no JSON output
     And the output should contain
       """
-      Hook failures can't be represented in JSON reports, thus none is created for cypress/integration/a.feature.
+      Hook failures can't be represented in JSON reports, thus none is created for cypress/e2e/a.feature.
       """

--- a/features/json_report.feature
+++ b/features/json_report.feature
@@ -69,7 +69,6 @@ Feature: JSON formatter
     Then it passes
     And there should be a JSON output similar to "fixtures/multiple-features.json"
 
-  @skip
   Scenario: failing step
     Given additional Cypress configuration
       """
@@ -96,7 +95,6 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/failing-step.json"
 
-  @skip
   Scenario: undefined step
     Given additional Cypress configuration
       """
@@ -120,7 +118,6 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/undefined-steps.json"
 
-  @skip
   Scenario: pending step
     Given additional Cypress configuration
       """
@@ -200,7 +197,6 @@ Feature: JSON formatter
     Then it fails
     And the JSON report should contain an image attachment for what appears to be a screenshot
 
-  @skip
   Scenario: retried
     Given additional Cypress configuration
       """
@@ -230,7 +226,6 @@ Feature: JSON formatter
     And there should be a JSON output similar to "fixtures/retried.json"
     # And there should be a JSON output similar to "fixtures/passed-example.json"
 
-  @skip
   Scenario: failing Before hook
     Given additional Cypress configuration
       """
@@ -256,7 +251,6 @@ Feature: JSON formatter
     Then it fails
     And there should be a JSON output similar to "fixtures/failing-before.json"
 
-  @skip
   Scenario: failing After hook
     Given additional Cypress configuration
       """

--- a/features/loaders/browserify.feature
+++ b/features/loaders/browserify.feature
@@ -1,7 +1,7 @@
 @no-default-plugin
 Feature: browserify + typescript
   Scenario:
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/loaders/esbuild.feature
+++ b/features/loaders/esbuild.feature
@@ -1,7 +1,7 @@
 @no-default-plugin
 Feature: esbuild + typescript
   Scenario:
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/loaders/webpack.feature
+++ b/features/loaders/webpack.feature
@@ -1,7 +1,7 @@
 @no-default-plugin
 Feature: webpack + typescript
   Scenario:
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/localisation.feature
+++ b/features/localisation.feature
@@ -1,6 +1,6 @@
 Feature: localisation
   Scenario: norwegian
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       # language: no
       Egenskap: en funksjonalitet

--- a/features/mixing_types.feature
+++ b/features/mixing_types.feature
@@ -1,4 +1,3 @@
-@skip
 Feature: mixing feature and non-feature specs
   Background:
     Given additional Cypress configuration

--- a/features/mixing_types.feature
+++ b/features/mixing_types.feature
@@ -1,14 +1,15 @@
+@skip
 Feature: mixing feature and non-feature specs
   Background:
     Given additional Cypress configuration
       """
       {
-        "testFiles": "**/*.{spec.js,feature}"
+        "specPattern": "**/*.{spec.js,feature}"
       }
       """
 
   Scenario: one feature and non-feature specs
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       @foo
       Feature: a feature name
@@ -23,7 +24,7 @@ Feature: mixing feature and non-feature specs
         expect(doesFeatureMatch("@foo")).to.be.true;
       });
       """
-    And a file named "cypress/integration/b.spec.js" with:
+    And a file named "cypress/e2e/b.spec.js" with:
       """
       const { isFeature } = require("@badeball/cypress-cucumber-preprocessor");
       it("should work", () => {

--- a/features/nested_steps.feature
+++ b/features/nested_steps.feature
@@ -1,13 +1,13 @@
 Feature: nesten steps
 
   Scenario: invoking step from another step
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name
           Given a nested step
       """
-    And a file named "cypress/integration/a.js" with:
+    And a file named "cypress/e2e/a.js" with:
       """
       const { Given, Step } = require("@badeball/cypress-cucumber-preprocessor");
       Given("a nested step", function() {

--- a/features/parse_error.feature
+++ b/features/parse_error.feature
@@ -1,7 +1,7 @@
 Feature: parse errors
 
   Scenario: tagged rules
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         @tag

--- a/features/scenario_outlines.feature
+++ b/features/scenario_outlines.feature
@@ -1,7 +1,7 @@
 Feature: scenario outlines and examples
 
   Scenario: placeholder in step
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -19,7 +19,7 @@ Feature: scenario outlines and examples
     Then it passes
 
   Scenario: placeholder in docstring
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -42,7 +42,7 @@ Feature: scenario outlines and examples
     Then it passes
 
   Scenario: placeholder in table
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario

--- a/features/skip.feature
+++ b/features/skip.feature
@@ -1,7 +1,7 @@
 Feature: skip
 
   Scenario: calling skip()
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/step_definitions.feature
+++ b/features/step_definitions.feature
@@ -3,13 +3,13 @@ Feature: step definitions
   Rule: it should by default look for step definitions in a couple of locations
 
     Example: step definitions with same filename
-      Given a file named "cypress/integration/a.feature" with:
+      Given a file named "cypress/e2e/a.feature" with:
         """
         Feature: a feature name
           Scenario: a scenario name
             Given a step
         """
-      And a file named "cypress/integration/a.js" with:
+      And a file named "cypress/e2e/a.js" with:
         """
         const { Given } = require("@badeball/cypress-cucumber-preprocessor");
         Given("a step", function() {});
@@ -18,13 +18,13 @@ Feature: step definitions
       Then it passes
 
     Example: step definitions in a directory with same name
-      Given a file named "cypress/integration/a.feature" with:
+      Given a file named "cypress/e2e/a.feature" with:
         """
         Feature: a feature name
           Scenario: a scenario name
             Given a step
         """
-      And a file named "cypress/integration/a/steps.js" with:
+      And a file named "cypress/e2e/a/steps.js" with:
         """
         const { Given } = require("@badeball/cypress-cucumber-preprocessor");
         Given("a step", function() {});
@@ -33,7 +33,7 @@ Feature: step definitions
       Then it passes
 
     Example: step definitions in a common directory
-      Given a file named "cypress/integration/a.feature" with:
+      Given a file named "cypress/e2e/a.feature" with:
         """
         Feature: a feature name
           Scenario: a scenario name

--- a/features/step_definitions/config_steps.ts
+++ b/features/step_definitions/config_steps.ts
@@ -1,6 +1,7 @@
 import { Given } from "@cucumber/cucumber";
 import path from "path";
 import { promises as fs } from "fs";
+import { writeCypressConfig } from "../support/helpers";
 
 async function addOrUpdateConfiguration(
   absoluteConfigPath: string,
@@ -43,7 +44,5 @@ Given("additional preprocessor configuration", async function (jsonContent) {
 });
 
 Given("additional Cypress configuration", async function (jsonContent) {
-  const absoluteConfigPath = path.join(this.tmpDir, "cypress.json");
-
-  await addOrUpdateConfiguration(absoluteConfigPath, jsonContent);
+  await writeCypressConfig(this.tmpDir, jsonContent);
 });

--- a/features/support/helpers.ts
+++ b/features/support/helpers.ts
@@ -5,3 +5,21 @@ export async function writeFile(filePath: string, fileContent: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
   await fs.writeFile(filePath, fileContent);
 }
+
+export async function writeCypressConfig(tmpPath: string, additionalJsonConfig: string = "undefined") {
+  await writeFile(
+    path.join(tmpPath, "cypress.config.ts"),
+    `import plugins from "./cypress/plugins/index";
+    
+export default {
+  e2e: {
+    specPattern: "**/*.feature",
+    video: false,
+    setupNodeEvents: plugins,
+    ...(${additionalJsonConfig} || {})
+  }
+}
+`);
+  
+}
+

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -2,7 +2,7 @@ import { After, Before, formatterHelpers } from "@cucumber/cucumber";
 import path from "path";
 import assert from "assert";
 import { promises as fs } from "fs";
-import { writeFile } from "./helpers";
+import { writeFile, writeCypressConfig } from "./helpers";
 
 const projectPath = path.join(__dirname, "..", "..");
 
@@ -20,18 +20,11 @@ Before(async function ({ gherkinDocument, pickle }) {
 
   await fs.rm(this.tmpDir, { recursive: true, force: true });
 
-  await writeFile(
-    path.join(this.tmpDir, "cypress.json"),
-    JSON.stringify(
-      {
-        testFiles: "**/*.feature",
-        video: false,
-        nodeVersion: "system",
-      },
-      null,
-      2
-    )
-  );
+  // create a default support file so that cypress doesn't fail
+  // cf. https://on.cypress.io/support-file-missing-or-invalid
+  await writeFile(path.join(this.tmpDir, "cypress/support/e2e.ts"), "");
+
+  await writeCypressConfig(this.tmpDir);
 
   await fs.mkdir(path.join(this.tmpDir, "node_modules", "@badeball"), {
     recursive: true,

--- a/features/tags/only_tag.feature
+++ b/features/tags/only_tag.feature
@@ -6,7 +6,7 @@ Feature: @only tag
    - Presence of this tag override any other tag filter
 
   Scenario: 1 / 2 scenarios tagged with @only
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @only
@@ -25,7 +25,7 @@ Feature: @only tag
     And it should appear to have skipped the scenario "another scenario"
 
   Scenario: 2 / 2 scenarios tagged with @only
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @only
@@ -44,7 +44,7 @@ Feature: @only tag
     Then it should appear as if both tests ran
 
   Scenario: 1 / 2 example table tagged with @only
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -71,7 +71,7 @@ Feature: @only tag
     And it should appear to have skipped the scenario "a scenario (example #2)"
 
   Scenario: 2 / 2 example table tagged with @only
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -99,14 +99,14 @@ Feature: @only tag
     And it should appear to have run the scenario "a scenario (example #2)"
 
   Scenario: one file with @only, one without
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @only
         Scenario: a scenario
           Given a step
       """
-    And a file named "cypress/integration/b.feature" with:
+    And a file named "cypress/e2e/b.feature" with:
       """
       Feature: b feature
         Scenario: another scenario
@@ -122,7 +122,7 @@ Feature: @only tag
     And it should appear to have run the scenario "another scenario"
 
   Scenario: specifying tags
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @only
@@ -143,7 +143,7 @@ Feature: @only tag
     And it should appear to have skipped the scenario "another scenario"
 
   Scenario: @focus (backwards compatibility)
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @focus

--- a/features/tags/skip_tag.feature
+++ b/features/tags/skip_tag.feature
@@ -5,7 +5,7 @@ Feature: @skip tag
    - Presence of this tag override any other tag filter
 
   Scenario: 1 / 2 scenarios tagged with @skip
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario: a scenario
@@ -24,7 +24,7 @@ Feature: @skip tag
     And it should appear to have skipped the scenario "another scenario"
 
   Scenario: 2 / 2 scenarios tagged with @skip
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @skip
@@ -43,7 +43,7 @@ Feature: @skip tag
     Then it should appear as if both tests were skipped
 
   Scenario: 1 / 2 example table tagged with @skip
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -70,7 +70,7 @@ Feature: @skip tag
     And it should appear to have skipped the scenario "a scenario (example #2)"
 
   Scenario: 2 / 2 example table tagged with @skip
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         Scenario Outline: a scenario
@@ -98,7 +98,7 @@ Feature: @skip tag
     And it should appear to have skipped the scenario "a scenario (example #2)"
 
   Scenario: specifying tags
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature
         @foo

--- a/features/tags/spec_filter.feature
+++ b/features/tags/spec_filter.feature
@@ -7,14 +7,14 @@ Feature: filter spec
         "filterSpecs": true
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       @foo
       Feature: some feature
         Scenario: first scenario
           Given a step
       """
-    And a file named "cypress/integration/b.feature" with:
+    And a file named "cypress/e2e/b.feature" with:
       """
       @bar
       Feature: some other feature

--- a/features/tags/tagged_hooks.feature
+++ b/features/tags/tagged_hooks.feature
@@ -29,7 +29,7 @@ Feature: tagged Hooks
       """
 
   Scenario: hooks filtered by tags on scenario
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature:
         @foo
@@ -41,7 +41,7 @@ Feature: tagged Hooks
     Then it passes
 
   Scenario: tags cascade from feature to scenario
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       @foo
       Feature:

--- a/features/tags/target_specific_scenarios_by_tag.feature
+++ b/features/tags/target_specific_scenarios_by_tag.feature
@@ -1,7 +1,7 @@
 Feature: target specific scenario
 
   Background:
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: some feature
         @a

--- a/features/tags/test_filter.feature
+++ b/features/tags/test_filter.feature
@@ -1,7 +1,7 @@
 Feature: test filter
 
   Scenario: with omitFiltered = false (default)
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: some feature
         Rule: first rule
@@ -29,7 +29,7 @@ Feature: test filter
         "omitFiltered": true
       }
       """
-    And a file named "cypress/integration/a.feature" with:
+    And a file named "cypress/e2e/a.feature" with:
       """
       Feature: some feature
         Rule: first rule

--- a/features/unambiguous_step_definitions.feature
+++ b/features/unambiguous_step_definitions.feature
@@ -1,7 +1,7 @@
 Feature:  unambiguous step definitions
 
   Scenario: step matching two definitions
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/undefined_step.feature
+++ b/features/undefined_step.feature
@@ -1,7 +1,7 @@
 Feature: undefined Steps
 
   Scenario:
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: a feature name
         Scenario: a scenario name

--- a/features/world_example.feature
+++ b/features/world_example.feature
@@ -1,7 +1,7 @@
 Feature: world
 
   Scenario: example of an World
-    Given a file named "cypress/integration/a.feature" with:
+    Given a file named "cypress/e2e/a.feature" with:
       """
       Feature: Simple maths
         In order to do maths
@@ -24,7 +24,7 @@ Feature: world
             |  99 |      1234 |   1333 |
             |  12 |         5 |     17 |
       """
-    And a file named "cypress/support/index.js" with:
+    And a file named "cypress/support/e2e.ts" with:
       """
       beforeEach(function () {
         // This mimics setWorldConstructor of cucumber-js.

--- a/lib/add-cucumber-preprocessor-plugin.ts
+++ b/lib/add-cucumber-preprocessor-plugin.ts
@@ -280,7 +280,7 @@ export default async function addCucumberPreprocessorPlugin(
   if (tags !== null && preprocessor.filterSpecs) {
     const node = parse(tags);
 
-    (config as any).testFiles = getTestFiles(
+    (config as any).specPattern = getTestFiles(
       config as unknown as ICypressConfiguration
     ).filter((testFile) => {
       const content = syncFs.readFileSync(testFile).toString("utf-8");

--- a/lib/preprocessor-configuration.ts
+++ b/lib/preprocessor-configuration.ts
@@ -295,8 +295,8 @@ export class PreprocessorConfiguration implements IPreprocessorConfiguration {
     return (
       this.environmentOverrides.stepDefinitions ??
       this.explicitValues.stepDefinitions ?? [
-        "cypress/integration/[filepath]/**/*.{js,ts}",
-        "cypress/integration/[filepath].{js,ts}",
+        "[filepath]/**/*.{js,ts}",
+        "[filepath].{js,ts}",
         "cypress/support/step_definitions/**/*.{js,ts}",
       ]
     );

--- a/lib/registry.ts
+++ b/lib/registry.ts
@@ -216,6 +216,6 @@ export function freeRegistry() {
 export function getRegistry() {
   return assertAndReturn(
     globalThis[globalPropertyName],
-    "Expected to find a global registry (this usually means you are trying to define steps or hooks in support/index.js, which is not supported)"
+    "Expected to find a global registry (this usually means you are trying to define steps or hooks in support/e2e.js, which is not supported)"
   );
 }

--- a/lib/step-definitions.test.ts
+++ b/lib/step-definitions.test.ts
@@ -15,7 +15,7 @@ function example(
   filepath: string,
   cypressConfiguration: Pick<
     ICypressConfiguration,
-    "projectRoot" | "integrationFolder"
+    "projectRoot"
   >,
   preprocessorConfiguration: Partial<IPreprocessorConfiguration>,
   expected: string[]
@@ -67,55 +67,53 @@ describe("pathParts()", () => {
 
 describe("getStepDefinitionPatterns()", () => {
   example(
-    "/foo/bar/cypress/integration/baz.feature",
+    "/foo/bar/cypress/e2e/baz.feature",
     {
       projectRoot: "/foo/bar",
-      integrationFolder: "cypress/integration",
     },
     {},
     [
-      "/foo/bar/cypress/integration/baz/**/*.{js,ts}",
-      "/foo/bar/cypress/integration/baz.{js,ts}",
+      "/foo/bar/cypress/e2e/baz/**/*.{js,ts}",
+      "/foo/bar/cypress/e2e/baz.{js,ts}",
       "/foo/bar/cypress/support/step_definitions/**/*.{js,ts}",
     ]
   );
 
   example(
-    "/cypress/integration/foo/bar/baz.feature",
+    "/cypress/e2e/foo/bar/baz.feature",
     {
       projectRoot: "/",
-      integrationFolder: "cypress/integration",
     },
     {
-      stepDefinitions: "cypress/integration/[filepath]/step_definitions/*.ts",
+      stepDefinitions: "[filepath]/step_definitions/*.ts",
     },
-    ["/cypress/integration/foo/bar/baz/step_definitions/*.ts"]
+    ["/cypress/e2e/foo/bar/baz/step_definitions/*.ts"]
   );
 
   example(
-    "/cypress/integration/foo/bar/baz.feature",
+    "/qux/cypress/e2e/foo/bar/baz.feature",
     {
-      projectRoot: "/",
-      integrationFolder: "cypress/integration",
+      projectRoot: "/qux",
     },
     {
-      stepDefinitions: "cypress/integration/[filepart]/step_definitions/*.ts",
+      stepDefinitions: "[filepart]/step_definitions/*.ts",
     },
     [
-      "/cypress/integration/foo/bar/baz/step_definitions/*.ts",
-      "/cypress/integration/foo/bar/step_definitions/*.ts",
-      "/cypress/integration/foo/step_definitions/*.ts",
-      "/cypress/integration/step_definitions/*.ts",
+      "/qux/cypress/e2e/foo/bar/baz/step_definitions/*.ts",
+      "/qux/cypress/e2e/foo/bar/step_definitions/*.ts",
+      "/qux/cypress/e2e/foo/step_definitions/*.ts",
+      "/qux/cypress/e2e/step_definitions/*.ts",
+      "/qux/cypress/step_definitions/*.ts",
+      "/qux/step_definitions/*.ts",
     ]
   );
 
-  it("should error when provided a path not within integrationFolder", () => {
+  it("should error when provided a path not within projectRoot", () => {
     assert.throws(() => {
       getStepDefinitionPatterns(
         {
           cypress: {
-            projectRoot: "/foo/bar",
-            integrationFolder: "cypress/integration",
+            projectRoot: "/qux",
           },
           preprocessor: {
             stepDefinitions: [],
@@ -123,7 +121,7 @@ describe("getStepDefinitionPatterns()", () => {
         },
         "/foo/bar/cypress/features/baz.feature"
       );
-    }, "/foo/bar/cypress/features/baz.feature is not within cypress/integration");
+    }, "/foo/bar/cypress/features/baz.feature is not within /qux");
   });
 
   it("should error when provided a path not within cwd", () => {
@@ -132,13 +130,12 @@ describe("getStepDefinitionPatterns()", () => {
         {
           cypress: {
             projectRoot: "/baz",
-            integrationFolder: "cypress/integration",
           },
           preprocessor: {
             stepDefinitions: [],
           },
         },
-        "/foo/bar/cypress/integration/baz.feature"
+        "/foo/bar/cypress/e2e/baz.feature"
       );
     }, "/foo/bar/cypress/features/baz.feature is not within /baz");
   });

--- a/lib/step-definitions.ts
+++ b/lib/step-definitions.ts
@@ -61,22 +61,15 @@ export function pathParts(relativePath: string): string[] {
 
 export function getStepDefinitionPatterns(
   configuration: {
-    cypress: Pick<ICypressConfiguration, "projectRoot" | "integrationFolder">;
+    cypress: Pick<ICypressConfiguration, "projectRoot">;
     preprocessor: IPreprocessorConfiguration;
   },
   filepath: string
 ): string[] {
-  const fullIntegrationFolder = path.isAbsolute(
-    configuration.cypress.integrationFolder
-  )
-    ? configuration.cypress.integrationFolder
-    : path.join(
-        configuration.cypress.projectRoot,
-        configuration.cypress.integrationFolder
-      );
+  const projectRoot = configuration.cypress.projectRoot;
 
-  if (!isPathInside(filepath, fullIntegrationFolder)) {
-    throw new Error(`${filepath} is not inside ${fullIntegrationFolder}`);
+  if (!isPathInside(filepath, projectRoot)) {
+    throw new Error(`${filepath} is not inside ${projectRoot}`);
   }
 
   debug(
@@ -86,7 +79,7 @@ export function getStepDefinitionPatterns(
   );
 
   const filepathReplacement = trimFeatureExtension(
-    path.relative(fullIntegrationFolder, filepath)
+    path.relative(projectRoot, filepath)
   );
 
   debug(`replacing [filepath] with ${util.inspect(filepathReplacement)}`);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "prepublishOnly": "npm run clean && npm run build && npm run test"
   },
   "dependencies": {
-    "@badeball/cypress-configuration": "^2.1.0",
+    "@badeball/cypress-configuration": "^3.0.0",
     "@cucumber/cucumber-expressions": "^15.0.1",
     "@cucumber/gherkin": "^15.0.2",
     "@cucumber/messages": "^13.2.1",
@@ -64,7 +64,7 @@
     "@types/debug": "^4.1.7",
     "@types/glob": "^7.2.0",
     "@types/stream-buffers": "^3.0.4",
-    "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "cypress": "^10.0.0",
     "dtslint": "^4.2.1",
     "esbuild": "^0.14.23",
     "mocha": "^9.2.1",
@@ -79,7 +79,7 @@
   },
   "peerDependencies": {
     "@cypress/browserify-preprocessor": "^3.0.1",
-    "cypress": "^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0",
+    "cypress": "^10.0.0",
     "esbuild": "^0.14.23"
   },
   "peerDependenciesMeta": {

--- a/test/run-all-specs.ts
+++ b/test/run-all-specs.ts
@@ -32,28 +32,25 @@ describe("Run all specs", () => {
     await fs.rm(this.tmpDir, { recursive: true, force: true });
 
     await writeFile(
-      path.join(this.tmpDir, "cypress.json"),
-      JSON.stringify({
-        testFiles: "**/*.feature",
-        video: false,
-      })
-    );
+      path.join(this.tmpDir, "cypress.config.js"),
+      `const { createEsbuildPlugin } = require("@badeball/cypress-cucumber-preprocessor/esbuild");
+const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
 
-    await writeFile(
-      path.join(this.tmpDir, "cypress", "plugins", "index.js"),
-      `
-        const { createEsbuildPlugin } = require("@badeball/cypress-cucumber-preprocessor/esbuild");
-        const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
-
-        module.exports = (on, config) => {
-          on(
-            "file:preprocessor",
-            createBundler({
-              plugins: [createEsbuildPlugin(config)]
-            })
-          );
-        }
-      `
+module.exports = {
+  e2e: {
+    specPattern: "**/*.feature",
+    video: false,
+    setupNodeEvents(on, config) {
+      on(
+        "file:preprocessor",
+        createBundler({
+          plugins: [createEsbuildPlugin(config)]
+        })
+      );
+    }
+  }
+}
+`
     );
 
     await fs.mkdir(path.join(this.tmpDir, "node_modules", "@badeball"), {
@@ -84,22 +81,22 @@ describe("Run all specs", () => {
     `;
 
     await writeFile(
-      path.join(this.tmpDir, "cypress", "integration", "a.feature"),
+      path.join(this.tmpDir, "cypress", "e2e", "a.feature"),
       feature
     );
 
     await writeFile(
-      path.join(this.tmpDir, "cypress", "integration", "a.ts"),
+      path.join(this.tmpDir, "cypress", "e2e", "a.ts"),
       steps
     );
 
     await writeFile(
-      path.join(this.tmpDir, "cypress", "integration", "b.feature"),
+      path.join(this.tmpDir, "cypress", "e2e", "b.feature"),
       feature
     );
 
     await writeFile(
-      path.join(this.tmpDir, "cypress", "integration", "b.ts"),
+      path.join(this.tmpDir, "cypress", "e2e", "b.ts"),
       steps
     );
 


### PR DESCRIPTION
related to #722 . 

Goes in pair with badeball/cypress-configuration/pull/2, which must be merged first. Given that the resulting new cypress-configuration is 3.0.0, there's nothing to do to this PR (version has already been updated in package.json).

- fix cypress 10 incompatibility issues (unfortunately it breaks compatibility with older versions of Cypress).
- fix integration & unit tests
- update examples
- update documentations
- update CHANGELOG

PS. Sorry for the big commit.

