### PR TITLE
Fix code example in Quick Start docs

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -10,7 +10,7 @@ $ npm install @badeball/cypress-cucumber-preprocessor
 
 ```ts
 import { defineConfig } from "cypress";
-import createBundler from "@bahmutov/cypress-esbuild-preprocessor";
+import * as createBundler from "@bahmutov/cypress-esbuild-preprocessor";
 import { addCucumberPreprocessorPlugin } from "@badeball/cypress-cucumber-preprocessor";
 import createEsbuildPlugin from "@badeball/cypress-cucumber-preprocessor/esbuild";
 


### PR DESCRIPTION
`@bahmutov/cypress-esbuild-preprocessor` doesn't have a default export:

```
module.exports = createBundler
```

The old imports produced a type error when loading Cypress:

```
TypeError: (0 , cypress_esbuild_preprocessor_1.default) is not a function
    at cypress.config.ts:17:22
    at step (cypress.config.ts:33:23)
    at Object.next (cypress.config.ts:14:53)
    at fulfilled (cypress.config.ts:5:58)
```