### PR TITLE
Export defineStep as "And" as per gherkin definitions

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,7 +63,7 @@ export function defineStep<T extends unknown[]>(
   throw createUnimplemented();
 }
 
-export { defineStep as Given, defineStep as When, defineStep as Then };
+export { defineStep as Given, defineStep as When, defineStep as Then, defineStep as And };
 
 export function Step(
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/lib/methods.ts
+++ b/lib/methods.ts
@@ -126,6 +126,7 @@ export {
   defineStep as Given,
   defineStep as When,
   defineStep as Then,
+  defineStep as And,
   defineStep,
   runStepDefininition as Step,
   defineParameterType,


### PR DESCRIPTION
I'm not sure if there was any particular reason to not export `And` as a step definition, if there was not any, here's a PR that adds it, and if there was, I would be delighted if you explained why it's being omitted.

Here's the reference on Gherkin syntax:
https://cucumber.io/docs/gherkin/reference/#and-but

