### PR TITLE
add example value to testname

### DIFF
--- a/lib/create-tests.ts
+++ b/lib/create-tests.ts
@@ -215,8 +215,10 @@ function createScenario(
       const pickle = findPickleById(context, exampleId);
 
       const baseName = pickle.name || "<unamed scenario>";
-
-      const exampleName = `${baseName} (example #${i + 1})`;
+ 
+      const  altName = scenario.examples[0].tableBody[i].cells[0].value || ""
+       
+      const exampleName = (altName === "") ? `${baseName} #(example #${i + 1})` : `${baseName} #${altName}`; 
 
       createPickle(context, { ...scenario, name: exampleName }, pickle);
     }

--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "watch": "tsc --watch",
     "fmt": "prettier --ignore-path .gitignore --write '**/*.ts'",
     "test": "npm run test:fmt && npm run test:lint && npm run test:types && npm run test:unit && npm run test:integration",
-    "test:fmt": "prettier --ignore-path .gitignore --check '**/*.ts'",
+    "test:fmt": "prettier --ignore-path .gitignore --check '**/*.ts' --no-error-on-unmatched-pattern",
     "test:lint": "eslint .",
     "test:types": "tsd",
     "test:unit": "mocha lib/**/*.test.ts",
     "test:run-all-specs": "mocha --timeout 0 test/run-all-specs.ts",
     "test:integration": "cucumber-js",
+    "prepare" : "npm run clean && npm run build",
     "prepublishOnly": "npm run clean && npm run build && npm run test"
   },
   "dependencies": {


### PR DESCRIPTION
Hi, 
I'm using your cucumber preprocessor for running tests and allure-report for reporting. 
Since the examples where always listed as  \#(example \#1), and forced me to check, which parameter failed a test, I added the value towards the testname. 

I'm running on my fork now, but I belive, this is something more people would like. 

Attention: I did only update the source, but did not modify the tests

best, 
BerSomBen