### PR TITLE
Implement configurable hiding of internal spec properties

### DIFF
--- a/features/issues/908.feature
+++ b/features/issues/908.feature
@@ -1,0 +1,33 @@
+# https://github.com/badeball/cypress-cucumber-preprocessor/issues/908
+
+Feature: hide internals from cypress environment
+  Scenario:
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      Feature: a feature
+        Scenario: hide internal state by default
+          * the internal state should not be visible
+
+        @reportInternalCucumberState
+        Scenario: expose internal state with tag
+          * the internal state should be visible
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+      const { Then } = require("@badeball/cypress-cucumber-preprocessor");
+      const { INTERNAL_SPEC_PROPERTIES } = require("@badeball/cypress-cucumber-preprocessor/lib/constants");
+
+      Then("the internal state should not be visible", () => {
+        const serializedProperties = JSON.stringify(Cypress.env(INTERNAL_SPEC_PROPERTIES));
+
+        expect(serializedProperties).to.be.undefined;
+      });
+
+      Then("the internal state should be visible", () => {
+        const serializedProperties = JSON.stringify(Cypress.env(INTERNAL_SPEC_PROPERTIES));
+
+        expect(serializedProperties).not.to.be.undefined;
+      });
+      """
+    When I run cypress
+    Then it passes

--- a/features/issues/908.feature
+++ b/features/issues/908.feature
@@ -14,19 +14,32 @@ Feature: hide internals from cypress environment
       """
     And a file named "cypress/support/step_definitions/steps.js" with:
       """
+      const { inspect } = require('util');
       const { Then } = require("@badeball/cypress-cucumber-preprocessor");
       const { INTERNAL_SPEC_PROPERTIES } = require("@badeball/cypress-cucumber-preprocessor/lib/constants");
 
       Then("the internal state should not be visible", () => {
-        const serializedProperties = JSON.stringify(Cypress.env(INTERNAL_SPEC_PROPERTIES));
+        const properties = Cypress.env(INTERNAL_SPEC_PROPERTIES);
+        const serializedProperties = JSON.stringify(properties);
+        const inspectedProperties = inspect(properties, {depth: 0});
 
+        expect(properties).not.to.be.undefined;
+        expect(properties.pickle).to.be.undefined;
         expect(serializedProperties).to.be.undefined;
+        expect(inspectedProperties).to.be.equal('{}');
       });
 
       Then("the internal state should be visible", () => {
-        const serializedProperties = JSON.stringify(Cypress.env(INTERNAL_SPEC_PROPERTIES));
+        const properties = Cypress.env(INTERNAL_SPEC_PROPERTIES);
+        const serializedProperties = JSON.stringify(properties);
+        const inspectedProperties = inspect(properties, {depth: 0});
 
+        expect(properties).not.to.be.undefined;
+        expect(properties.pickle).not.to.be.undefined;
         expect(serializedProperties).not.to.be.undefined;
+        // Must be more than an empty object, cannot test the exact string because
+        // it contains random values in a random order.
+        expect(inspectedProperties).to.have.length.of.at.least(3);
       });
       """
     When I run cypress

--- a/lib/create-tests.ts
+++ b/lib/create-tests.ts
@@ -112,8 +112,48 @@ export interface InternalSuiteProperties {
   isEventHandlersAttached?: boolean;
 }
 
+class InternalSpecPropertiesReference {
+  private static referenceMap = new WeakMap<
+    InternalSpecPropertiesReference,
+    InternalSpecProperties
+  >();
+
+  private constructor() {
+    // Empty constructor just to set private visibility
+  }
+
+  public static new(
+    scenarioName: string,
+    properties: InternalSpecProperties
+  ): InternalSpecPropertiesReference {
+    const reference = new this();
+
+    this.referenceMap.set(reference, properties);
+
+    return reference;
+  }
+
+  public dereference(): InternalSpecProperties {
+    // Non-null assertion is safe because an instance of reference is only given out after it is included
+    // in the reference map.
+    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+    return InternalSpecPropertiesReference.referenceMap.get(this)!;
+  }
+
+  public toJSON(): void {
+    // Noop override to hide the reference from serialization.
+    // Any property pointing to a reference will be ignored by JSON.stringify
+  }
+}
+
 function retrieveInternalSpecProperties(): InternalSpecProperties {
-  return Cypress.env(INTERNAL_SPEC_PROPERTIES);
+  const envValue = Cypress.env(INTERNAL_SPEC_PROPERTIES);
+
+  if (envValue instanceof InternalSpecPropertiesReference) {
+    return envValue.dereference();
+  }
+
+  return envValue;
 }
 
 function retrieveInternalSuiteProperties():
@@ -318,7 +358,11 @@ function createPickle(
     remainingSteps: [...steps],
   };
 
-  const internalEnv = { [INTERNAL_SPEC_PROPERTIES]: internalProperties };
+  const internalEnv = {
+    [INTERNAL_SPEC_PROPERTIES]: tags.includes("@reportInternalCucumberState")
+      ? internalProperties
+      : InternalSpecPropertiesReference.new(scenarioName, internalProperties),
+  };
 
   const suiteOptions = tags
     .filter(looksLikeOptions)

--- a/lib/create-tests.ts
+++ b/lib/create-tests.ts
@@ -146,7 +146,7 @@ class InternalSpecPropertiesReference {
   }
 }
 
-function retrieveInternalSpecProperties(): InternalSpecProperties {
+export function retrieveInternalSpecProperties(): InternalSpecProperties {
   const envValue = Cypress.env(INTERNAL_SPEC_PROPERTIES);
 
   if (envValue instanceof InternalSpecPropertiesReference) {

--- a/lib/methods.ts
+++ b/lib/methods.ts
@@ -7,7 +7,10 @@ import {
   INTERNAL_SPEC_PROPERTIES,
   TASK_CREATE_STRING_ATTACHMENT,
 } from "./constants";
-import { InternalSpecProperties } from "./create-tests";
+import {
+  InternalSpecProperties,
+  retrieveInternalSpecProperties,
+} from "./create-tests";
 
 import DataTable from "./data_table";
 
@@ -115,7 +118,7 @@ export const NOT_FEATURE_ERROR =
 
 function doesFeatureMatch(expression: string) {
   const { pickle } = assertAndReturn(
-    Cypress.env(INTERNAL_SPEC_PROPERTIES),
+    retrieveInternalSpecProperties(),
     NOT_FEATURE_ERROR
   ) as InternalSpecProperties;
 


### PR DESCRIPTION
Instead of setting the internal properties within Cypress environment, which gets reported to the recording dashboard, set a reference instance that is ignored when serializing.

- Fixes #908 

Using a reference object allows for the environment object itself to be simpler, not even holding a reference to the huge internal properties object, meaning that a user (or third-party library) can even call `console.log(inspect(Cypress.env(), {depth: null}))` and the huge internal properties won't be shown.

The previous behavior, with the entire object being added to the cypress environment and reported to the recording dashboard, can be enabled by using the tag `@reportInternalCucumberState`