### PR TITLE
fix: Use cjs extension for diagnose output

### DIFF
--- a/features/diagnostics.feature
+++ b/features/diagnostics.feature
@@ -186,3 +186,32 @@ Feature: diagnostics
              - 'a step' (cypress/support/step_definitions/steps.js:2)
              - /a step/ (cypress/support/step_definitions/steps.js:3)
         """
+
+    Scenario: module package
+      Given a file named "package.json" with:
+        """
+        {
+          "type": "module"
+        }
+        """
+      And a file named "cypress/e2e/a.feature" with:
+        """
+        Feature: a feature name
+          Scenario: a scenario name
+            Given a step
+        """
+      And a file named "cypress/support/step_definitions/steps.js" with:
+        """
+        const { Given } = require("@badeball/cypress-cucumber-preprocessor");
+        Given("a step", function() {});
+        """
+      When I run diagnostics
+      Then the output should contain
+        """
+        ┌────────────────┬─────────────────────────────────────────────┐
+        │ Pattern / Text │ Location                                    │
+        ├────────────────┼─────────────────────────────────────────────┤
+        │ 'a step'       │ cypress/support/step_definitions/steps.js:2 │
+        │   a step       │ cypress/e2e/a.feature:3                     │
+        └────────────────┴─────────────────────────────────────────────┘
+        """

--- a/features/diagnostics.feature
+++ b/features/diagnostics.feature
@@ -202,7 +202,7 @@ Feature: diagnostics
         """
       And a file named "cypress/support/step_definitions/steps.js" with:
         """
-        const { Given } = require("@badeball/cypress-cucumber-preprocessor");
+        import { Given } from "@badeball/cypress-cucumber-preprocessor";
         Given("a step", function() {});
         """
       When I run diagnostics

--- a/lib/diagnostics/diagnose.ts
+++ b/lib/diagnostics/diagnose.ts
@@ -122,7 +122,7 @@ export async function diagnose(configuration: {
 
     const outputFileName = path.join(
       configuration.cypress.projectRoot,
-      ".output-" + randomPart + ".js"
+      ".output-" + randomPart + ".cjs"
     );
 
     let registry: Registry;
@@ -150,7 +150,7 @@ export async function diagnose(configuration: {
         }
 
         throw new Error(
-          `Failed to compile steø definitions of ${testFile}, with errors shown above...`
+          `Failed to compile step definitions of ${testFile}, with errors shown above...`
         );
       }
 


### PR DESCRIPTION
I ran into a problem using the diagnostics because my package.json type is set to module. To get the diagnostics script to run I needed to rename the output file to use the cjs extension instead of js. This PR fixes that and a typo