### PR TITLE
document using the not predicate on tags

### DIFF
--- a/docs/tags.md
+++ b/docs/tags.md
@@ -39,6 +39,15 @@ Tags are inherited by child elements. Tags that are placed above a `Feature` wil
 
 Normally when running a subset of scenarios using `cypress run --env tags=@foo`, you could potentially encounter files containing no matching scenarios. These can be pre-filtered away by setting `filterSpecs` to `true`, thus saving you execution time.
 
+## Ignoring a subset of scenarios
+
+You can ignore scenarios using `cypress run --env tags="not @foo"`.  If you define this in the `package.json`, be sure to escape the quotes, e.g. 
+```
+ "scripts": {
+    "runFeaturesNotIgnore": "node_modules\\.bin\\cypress run --env tags=\"not @foo\" "
+  },
+```
+
 ## Omit filtered tests
 
 By default, all filtered tests are made *pending* using `it.skip` method. If you want to completely omit them, set `omitFiltered` to `true`.
@@ -48,3 +57,4 @@ By default, all filtered tests are made *pending* using `it.skip` method. If you
 In the absence of a `tags` value and presence of a scenario with `@only`, only said scenario will run. You can in other words use this tag as you would use `.only()` in Mocha.
 
 Similarly, scenarios tagged with `@skip` will always be skipped, despite being tagged with something else matching a tag filter.
+


### PR DESCRIPTION
Added short description of how to use the `not` predicate in the `tags` option.  Also provided example of using it w/in `package.json` 