### PR TITLE
Fix json generation fail due to empty lines in cucumber-messages.ndjson

### DIFF
--- a/lib/add-cucumber-preprocessor-plugin.ts
+++ b/lib/add-cucumber-preprocessor-plugin.ts
@@ -158,6 +158,7 @@ export async function afterRunHandler(config: Cypress.PluginConfigOptions) {
       .toString()
       .trim()
       .split("\n")
+      .filter((l) => l != "")
       .map((line) => JSON.parse(line));
 
     let jsonOutput: string | undefined;


### PR DESCRIPTION
Sometimes you can find empty lines on the generated `cucumber-messages.ndjson` which is used to generate the Cucumber Json report. 

![Screenshot2267](https://user-images.githubusercontent.com/3948733/231264062-afef483e-4e73-4763-947a-4f5b0ad4f247.png)

When this happens the report won't be generated due to a 'Expected a JSON output of string, but got  ' error

This PR attempts to fix this by filtering empty strings out