### PR TITLE
Correcting the import of `createEsbuildPlugin`

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -14,7 +14,7 @@ $ npm install @badeball/cypress-cucumber-preprocessor
 import { defineConfig } from "cypress";
 import createBundler from "@bahmutov/cypress-esbuild-preprocessor";
 import { addCucumberPreprocessorPlugin } from "@badeball/cypress-cucumber-preprocessor";
-import createEsbuildPlugin from "@badeball/cypress-cucumber-preprocessor/esbuild";
+import { createEsbuildPlugin } from "@badeball/cypress-cucumber-preprocessor/esbuild";
 
 export default defineConfig({
   e2e: {


### PR DESCRIPTION
In the distributed package files, the `esbuild.js` file has an `export.default` which will work in less instances than the named export `export.createEsbuildPlugin`.