### PR TITLE
Expose `IPreprocessorConfiguration` configuration interface

### DIFF
--- a/lib/entrypoint-node.ts
+++ b/lib/entrypoint-node.ts
@@ -7,7 +7,7 @@ import {
   IStepDefinitionBody,
 } from "./public-member-types";
 
-export { resolve as resolvePreprocessorConfiguration } from "./preprocessor-configuration";
+export { resolve as resolvePreprocessorConfiguration, IPreprocessorConfiguration as CucumberPreprocessorConfiguration } from "./preprocessor-configuration";
 
 export {
   getStepDefinitionPatterns,

--- a/lib/entrypoint-node.ts
+++ b/lib/entrypoint-node.ts
@@ -7,7 +7,10 @@ import {
   IStepDefinitionBody,
 } from "./public-member-types";
 
-export { resolve as resolvePreprocessorConfiguration, IPreprocessorConfiguration as CucumberPreprocessorConfiguration } from "./preprocessor-configuration";
+export {
+  resolve as resolvePreprocessorConfiguration,
+  IPreprocessorConfiguration as CucumberPreprocessorConfiguration,
+} from "./preprocessor-configuration";
 
 export {
   getStepDefinitionPatterns,


### PR DESCRIPTION
As a follow-up to [this discussion](https://github.com/badeball/cypress-cucumber-preprocessor/discussions/1056), I would like to re-use the configuration type which is used internally by the `cypress-cucumber-preprocessor`, e.g.:

```ts
import { 
  CucumberPreprocessorConfiguration,
  resolvePreprocessorConfiguration
} from "@badeball/cypress-cucumber-preprocessor";

export interface MyOwnConfiguration {
  color: "red" | "green";
  preprocessor: CucumberPreprocessorConfiguration;
}

// ...

export async function init(): MyOwnConfiguration {
  return {
    color: "green",
    preprocessor: await resolvePreprocessorConfiguration(...)
  }
}
```

It would improve type safety and eliminate any code duplication (currently I'd need to duplicate the interface if I wanted to use it). From a consistency perspective it also makes sense to expose the return types of functions which are exposed themselves.

This PR simply re-exports the `IPreprocessorConfiguration` interface along with the `resolvePreprocessorConfiguration` function.


