### PR TITLE
fix(hook): avoid failure on task retry in before handler

### DIFF
--- a/lib/plugin-event-handlers.ts
+++ b/lib/plugin-event-handlers.ts
@@ -322,7 +322,10 @@ export async function beforeSpecHandler(
         }
       }
       break;
-    // This happens in case of visting a new domain, ref. https://github.com/cypress-io/cypress/issues/26300.
+    // this happens in case of retrying a task in the before handler
+    case "before-spec":
+      break;
+    // This happens in case of visiting a new domain, ref. https://github.com/cypress-io/cypress/issues/26300.
     // In this case, we want to disgard messages obtained in the current test and allow execution to continue
     // as if nothing happened.
     case "step-started":


### PR DESCRIPTION
avoid following error when a tast is retried in before handler : 
```
An error was thrown in your plugins file while executing the handler for the before:spec event.

The error we received was:

Error: Unexpected state in beforeSpecHandler: before-spec (this might be a bug, please report at https://github.com/badeball/cypress-cucumber-preprocessor)
...
```