### PR TITLE
Update package.json to allow cypress 13.0.0 version

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@typescript-eslint/eslint-plugin": "^5.59.1",
     "@typescript-eslint/parser": "^5.59.1",
     "ast-types": "^0.15.2",
-    "cypress": "^10.0.0 || ^11.0.0 || ^12.0.0",
+    "cypress": "^10.0.0 || ^11.0.0 || ^12.0.0 || ^13.0.0",
     "eslint": "^8.39.0",
     "jsdom": "^21.1.1",
     "pngjs": "^7.0.0",


### PR DESCRIPTION
Hey! I've tried the package with new version of the cypress. It's working good, but the pipeline cannot handle version from the package.json. Here is a quick update 👍🏻 