### PR TITLE
doc(event-handler): Update template code to avoid build crash in beforeSpecHandler()

### DIFF
--- a/docs/event-handlers.md
+++ b/docs/event-handlers.md
@@ -73,7 +73,7 @@ export default defineConfig({
       });
 
       on("before:spec", async (spec) => {
-        await beforeSpecHandler(config);
+        await beforeSpecHandler(config, spec);
 
         // Your own `before:spec` code goes here.
       });


### PR DESCRIPTION
This is a quick fix on documentation to avoid build crash when copy and paste the code.

Encounted error:
```zsh
TypeError: Cannot read properties of undefined (reading 'name')
```

This error appears because there are no `spec` param passing to `beforeSpecHandler()`.