### PR TITLE
Diagnostics: Mock env as ObjectLike

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 dist/
 
+node_modules/
+
 # Temporary directory for test execution
 tmp/

--- a/lib/diagnostics/diagnose.ts
+++ b/lib/diagnostics/diagnose.ts
@@ -30,6 +30,10 @@ import {
 } from "../step-definitions";
 import { notNull } from "../helpers/type-guards";
 
+interface ObjectLike {
+  [key: string]: any;
+}
+
 export interface DiagnosticStep {
   source: string;
   line: number;
@@ -163,7 +167,9 @@ export async function diagnose(configuration: {
 
       const cypressMockGlobals = {
         Cypress: {
-          env() {},
+          env() {
+            return {} as ObjectLike;
+          },
           on() {},
           config() {},
         },


### PR DESCRIPTION
As [Cypress.env()](https://github.com/cypress-io/cypress/blob/develop/cli/types/cypress.d.ts#L522) returns an ObjectLike, I think it's safe to return the similar mock here.