### PR TITLE
Support testIsolation configuration tag on Feature and Rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@ lib/version.ts
 
 # Temporary directory for test execution
 tmp/
-node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ lib/version.ts
 
 # Temporary directory for test execution
 tmp/
+node_modules

--- a/features/suite_only_options.feature
+++ b/features/suite_only_options.feature
@@ -52,13 +52,43 @@ Feature: suite only options
       """
     And a file named "cypress/support/step_definitions/steps.js" with:
       """
-    const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
-    Given("a step", () => {
-    cy.get("body").invoke('html', 'Hello world')
-    });
-    Given("another step", () => {
-      cy.contains("Hello world").should("exist");
+      const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+      Given("a step", () => {
+        cy.get("body").invoke('html', 'Hello world')
+      });
+      Given("another step", () => {
+        cy.contains("Hello world").should("exist");
       });
       """
     When I run cypress
     Then it passes
+
+  Scenario: Configuring testIsolation on a Scenario fails
+    Given additional Cypress configuration
+      """
+      {
+        "e2e": {
+          "testIsolation": true
+        }
+      }
+      """
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      Feature: a feature
+        @testIsolation(false)
+        Scenario: a scenario
+          Given a step
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+      const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+      Given("a step", () => {
+        cy.get("body").invoke('html', 'Hello world')
+      });
+      """
+    When I run cypress
+    Then it fails
+    And the output should contain
+      """
+      Tag @testIsolation(false) can only be used on a Feature or a Rule
+      """

--- a/features/suite_only_options.feature
+++ b/features/suite_only_options.feature
@@ -1,3 +1,4 @@
+@cypress>=12
 Feature: suite only options
   Scenario: suite specific test isolation
     Given additional Cypress configuration

--- a/features/suite_only_options.feature
+++ b/features/suite_only_options.feature
@@ -1,6 +1,6 @@
 @cypress>=12
 Feature: suite only options
-  Scenario: suite specific test isolation
+  Scenario: Configuring testIsolation on a Feature
     Given additional Cypress configuration
       """
       {
@@ -26,6 +26,38 @@ Feature: suite only options
       });
       Given("another step", () => {
         cy.contains("Hello world").should("exist");
+      });
+      """
+    When I run cypress
+    Then it passes
+
+  Scenario: Configuring testIsolation on a Rule
+    Given additional Cypress configuration
+      """
+      {
+        "e2e": {
+          "testIsolation": true
+        }
+      }
+      """
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      Feature: a feature
+        @testIsolation(false)
+        Rule: a rule
+          Scenario: a scenario
+            Given a step
+          Scenario: another scenario
+            Then another step
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+    const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+    Given("a step", () => {
+    cy.get("body").invoke('html', 'Hello world')
+    });
+    Given("another step", () => {
+      cy.contains("Hello world").should("exist");
       });
       """
     When I run cypress

--- a/features/suite_only_options.feature
+++ b/features/suite_only_options.feature
@@ -1,0 +1,31 @@
+Feature: suite only options
+  Scenario: suite specific test isolation
+    Given additional Cypress configuration
+      """
+      {
+        "e2e": {
+          "testIsolation": true
+        }
+      }
+      """
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      @testIsolation(false)
+      Feature: a feature
+        Scenario: a scenario
+          Given a step
+        Scenario: another scenario
+          Then another step
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+      const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+      Given("a step", () => {
+        cy.get("body").invoke('html', 'Hello world')
+      });
+      Given("another step", () => {
+        cy.contains("Hello world").should("exist");
+      });
+      """
+    When I run cypress
+    Then it passes

--- a/features/suite_only_options.feature
+++ b/features/suite_only_options.feature
@@ -92,3 +92,71 @@ Feature: suite only options
       """
       Tag @testIsolation(false) can only be used on a Feature or a Rule
       """
+
+  Scenario: Configuring testIsolation on a Scenario Outline fails
+    Given additional Cypress configuration
+      """
+      {
+        "e2e": {
+          "testIsolation": true
+        }
+      }
+      """
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      Feature: a feature
+        @testIsolation(false)
+        Scenario Outline: a scenario
+          Given a step
+
+          Examples:
+            | foo |
+            | bar |
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+      const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+      Given("a step", () => {
+        cy.get("body").invoke('html', 'Hello world')
+      });
+      """
+    When I run cypress
+    Then it fails
+    And the output should contain
+      """
+      Tag @testIsolation(false) can only be used on a Feature or a Rule
+      """
+
+  Scenario: Configuring testIsolation on Examples fails
+    Given additional Cypress configuration
+      """
+      {
+        "e2e": {
+          "testIsolation": true
+        }
+      }
+      """
+    And a file named "cypress/e2e/a.feature" with:
+      """
+      Feature: a feature
+        Scenario Outline: a scenario
+          Given a step
+
+          @testIsolation(false)
+          Examples:
+            | foo |
+            | bar |
+      """
+    And a file named "cypress/support/step_definitions/steps.js" with:
+      """
+      const { Given, Then } = require("@badeball/cypress-cucumber-preprocessor");
+      Given("a step", () => {
+        cy.get("body").invoke('html', 'Hello world')
+      });
+      """
+    When I run cypress
+    Then it fails
+    And the output should contain
+      """
+      Tag @testIsolation(false) can only be used on a Feature or a Rule
+      """

--- a/features/support/helpers.ts
+++ b/features/support/helpers.ts
@@ -1,6 +1,7 @@
-import path from "path";
-import { promises as fs } from "fs";
 import assert from "assert";
+import { version as cypressVersion } from "cypress/package.json";
+import { promises as fs } from "fs";
+import path from "path";
 
 export async function writeFile(filePath: string, fileContent: string) {
   await fs.mkdir(path.dirname(filePath), { recursive: true });
@@ -106,3 +107,11 @@ export function stringToNdJson(content: string) {
 export function ndJsonToString(ndjson: any) {
   return ndjson.map((o: any) => JSON.stringify(o)).join("\n") + "\n";
 }
+
+export function isPost12() {
+  return parseInt(cypressVersion.split(".")[0], 10) >= 12;
+}
+
+export function isPre12() {
+  return !isPost12();
+}	

--- a/features/support/helpers.ts
+++ b/features/support/helpers.ts
@@ -114,4 +114,4 @@ export function isPost12() {
 
 export function isPre12() {
   return !isPost12();
-}	
+}

--- a/features/support/hooks.ts
+++ b/features/support/hooks.ts
@@ -1,8 +1,8 @@
 import { After, Before, formatterHelpers } from "@cucumber/cucumber";
-import path from "path";
 import assert from "assert";
 import { promises as fs } from "fs";
-import { writeFile } from "./helpers";
+import path from "path";
+import { isPre12, writeFile } from "./helpers";
 
 const projectPath = path.join(__dirname, "..", "..");
 
@@ -93,6 +93,12 @@ Before({ tags: "not @no-default-plugin" }, async function () {
         };
       `
   );
+});
+
+Before({ tags: "@cypress>=12" }, async function () {
+  if (isPre12()) {
+    return "skipped";
+  }
 });
 
 After(function () {

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -451,10 +451,24 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     `Expected to find scenario associated with id = ${pickle.astNodeIds?.[0]}`
   );
 
-  if ("tags" in scenario) {
-    for (const tag of scenario.tags) {
+  if ("tags" in scenario && 'id' in scenario) {
+    const tagsDefinedOnThisScenarioTagNameAstIdMap = scenario.tags.reduce((acc, tag) => {
+      acc[tag.name] = tag.id;
+      return acc;
+    }, {} as Record<string, string>);
+
+    if ('examples' in scenario) {
+      for (const example of scenario.examples) {
+        example.tags.forEach((tag) => {
+          tagsDefinedOnThisScenarioTagNameAstIdMap[tag.name] = tag.id;
+        });
+      }
+    }
+
+    for (const tag of pickle.tags) {
       if (
         looksLikeOptions(tag.name) &&
+        tagsDefinedOnThisScenarioTagNameAstIdMap[tag.name] === tag.astNodeId &&
         Object.keys(tagToCypressOptions(tag.name)).every(
           (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
         )

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -441,7 +441,6 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     [INTERNAL_SPEC_PROPERTIES]: internalProperties,
   };
 
-
   const scenario = assertAndReturn(
     context.astIdsMap.get(
       assertAndReturn(
@@ -452,7 +451,7 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     `Expected to find scenario associated with id = ${pickle.astNodeIds?.[0]}`
   );
 
-  if ('tags' in scenario) {
+  if ("tags" in scenario) {
     for (const tag of scenario.tags) {
       if (
         looksLikeOptions(tag.name) &&

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -357,7 +357,17 @@ function createRule(context: CompositionContext, rule: messages.Rule) {
     }
   }
 
-  describe(rule.name || "<unamed rule>", () => {
+  const suiteOptions = collectTagNames(rule.tags)
+    .filter(looksLikeOptions)
+    .map(tagToCypressOptions)
+    .filter((tag) => {
+      return Object.keys(tag).every(
+        (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
+      );
+    })
+    .reduce(Object.assign, {});
+
+  describe(rule.name || "<unamed rule>", suiteOptions, () => {
     if (rule.children) {
       for (const child of rule.children) {
         if (child.scenario) {

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -441,27 +441,31 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     [INTERNAL_SPEC_PROPERTIES]: internalProperties,
   };
 
-  pickle.tags.forEach((pickleTag) => {
-    for (const node of traverseGherkinDocument(gherkinDocument)) {
-      if ("tags" in node) {
-        for (const tag of node.tags) {
-          if (
-            looksLikeOptions(tag.name) &&
-            Object.keys(tagToCypressOptions(tag.name)).every(
-              (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
-            ) &&
-            tag.id === pickleTag.astNodeId &&
-            "id" in node &&
-            node.id === pickle.astNodeIds[0]
-          ) {
-            throw new Error(
-              `Tag ${tag.name} can only be used on a Feature or a Rule`
-            );
-          }
-        }
+
+  const scenario = assertAndReturn(
+    context.astIdsMap.get(
+      assertAndReturn(
+        pickle.astNodeIds?.[0],
+        "Expected to find at least one astNodeId"
+      )
+    ),
+    `Expected to find scenario associated with id = ${pickle.astNodeIds?.[0]}`
+  );
+
+  if ('tags' in scenario) {
+    for (const tag of scenario.tags) {
+      if (
+        looksLikeOptions(tag.name) &&
+        Object.keys(tagToCypressOptions(tag.name)).every(
+          (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
+        )
+      ) {
+        throw new Error(
+          `Tag ${tag.name} can only be used on a Feature or a Rule`
+        );
       }
     }
-  });
+  }
 
   const suiteOptions = tags
     .filter(looksLikeOptions)

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -34,7 +34,7 @@ import {
   HOOK_FAILURE_EXPR,
   INTERNAL_SPEC_PROPERTIES,
   INTERNAL_SUITE_PROPERTIES,
-  SUITE_CONFIGURATION_OPTIONS,
+  TEST_ISOLATION_CONFIGURATION_OPTION,
 } from "./constants";
 
 import {
@@ -291,8 +291,8 @@ function createFeature(context: CompositionContext, feature: messages.Feature) {
     .filter(looksLikeOptions)
     .map(tagToCypressOptions)
     .filter((tag) => {
-      return Object.keys(tag).every((key) =>
-        SUITE_CONFIGURATION_OPTIONS.includes(key)
+      return Object.keys(tag).every(
+        (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
       );
     })
     .reduce(Object.assign, {});
@@ -436,7 +436,7 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     .map(tagToCypressOptions)
     .filter((tag) =>
       Object.keys(tag).every(
-        (key) => !SUITE_CONFIGURATION_OPTIONS.includes(key)
+        (key) => key !== TEST_ISOLATION_CONFIGURATION_OPTION
       )
     )
     .reduce(Object.assign, {});

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -446,6 +446,10 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
       if ("tags" in node) {
         for (const tag of node.tags) {
           if (
+            looksLikeOptions(tag.name) &&
+            Object.keys(tagToCypressOptions(tag.name)).every(
+              (key) => key === TEST_ISOLATION_CONFIGURATION_OPTION
+            ) &&
             tag.id === pickleTag.astNodeId &&
             "id" in node &&
             node.id === pickle.astNodeIds[0]

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -451,13 +451,16 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     `Expected to find scenario associated with id = ${pickle.astNodeIds?.[0]}`
   );
 
-  if ("tags" in scenario && 'id' in scenario) {
-    const tagsDefinedOnThisScenarioTagNameAstIdMap = scenario.tags.reduce((acc, tag) => {
-      acc[tag.name] = tag.id;
-      return acc;
-    }, {} as Record<string, string>);
+  if ("tags" in scenario && "id" in scenario) {
+    const tagsDefinedOnThisScenarioTagNameAstIdMap = scenario.tags.reduce(
+      (acc, tag) => {
+        acc[tag.name] = tag.id;
+        return acc;
+      },
+      {} as Record<string, string>
+    );
 
-    if ('examples' in scenario) {
+    if ("examples" in scenario) {
       for (const example of scenario.examples) {
         example.tags.forEach((tag) => {
           tagsDefinedOnThisScenarioTagNameAstIdMap[tag.name] = tag.id;

--- a/lib/browser-runtime.ts
+++ b/lib/browser-runtime.ts
@@ -441,6 +441,24 @@ function createPickle(context: CompositionContext, pickle: messages.Pickle) {
     [INTERNAL_SPEC_PROPERTIES]: internalProperties,
   };
 
+  pickle.tags.forEach((pickleTag) => {
+    for (const node of traverseGherkinDocument(gherkinDocument)) {
+      if ("tags" in node) {
+        for (const tag of node.tags) {
+          if (
+            tag.id === pickleTag.astNodeId &&
+            "id" in node &&
+            node.id === pickle.astNodeIds[0]
+          ) {
+            throw new Error(
+              `Tag ${tag.name} can only be used on a Feature or a Rule`
+            );
+          }
+        }
+      }
+    }
+  });
+
   const suiteOptions = tags
     .filter(looksLikeOptions)
     .map(tagToCypressOptions)

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -7,3 +7,5 @@ export const INTERNAL_SUITE_PROPERTIES = INTERNAL_PROPERTY_NAME + "_suite";
 
 export const HOOK_FAILURE_EXPR =
   /Because this error occurred during a `[^`]+` hook we are skipping all of the remaining tests\./;
+
+export const SUITE_CONFIGURATION_OPTIONS = ["testIsolation"];

--- a/lib/constants.ts
+++ b/lib/constants.ts
@@ -8,4 +8,4 @@ export const INTERNAL_SUITE_PROPERTIES = INTERNAL_PROPERTY_NAME + "_suite";
 export const HOOK_FAILURE_EXPR =
   /Because this error occurred during a `[^`]+` hook we are skipping all of the remaining tests\./;
 
-export const SUITE_CONFIGURATION_OPTIONS = ["testIsolation"];
+export const TEST_ISOLATION_CONFIGURATION_OPTION = "testIsolation";


### PR DESCRIPTION
Implement https://github.com/badeball/cypress-cucumber-preprocessor/issues/1158

Allows setting `testIsolation` per test suite (as it's not supported on the individual test level).

Eg.

```gherkin
@testIsolation(false)
Feature: non-isolated tests
  ...
```

will apply `{ testIsolation: false }` to the `describe` block rather than each `it` within.

Also supported on `Rule`.
```gherkin
Feature: a feature
  @testIsolation(false)
  Rule: a rule

  Rule: another rule
```
