### PR TITLE
Added override flag

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -78,8 +78,10 @@ Every configuration option has a similar key which can be use to override it, sh
 | `messages.output`      | `messagesOutput`       | `cucumber-messages.ndjson`               |
 | `json.enabled`         | `jsonEnabled`          | `true`, `false`                          |
 | `json.output`          | `jsonOutput`           | `cucumber-report.json`                   |
+| `json.override`        | `jsonOverride`         | `true`, `false`                          |
 | `html.enabled`         | `htmlEnabled`          | `true`, `false`                          |
 | `html.output`          | `htmlOutput`           | `cucumber-report.html`                   |
+| `html.override`        | `htmlOverride`         | `true`, `false`                          |
 | `pretty.enabled`       | `prettyEnabled`        | `true`, `false`                          |
 | `filterSpecsMixedMode` | `filterSpecsMixedMode` | `hide`, `show`, `empty-set`              |
 | `filterSpecs`          | `filterSpecs`          | `true`, `false`                          |

--- a/docs/html-report.md
+++ b/docs/html-report.md
@@ -14,6 +14,8 @@ HTML reports are powered by [`@cucumber/html-formatter`](https://github.com/cucu
 
 The report is outputted to `cucumber-report.html` in the project directory, but can be configured through the `html.output` property.
 
+`html.override` is a boolean flag defaulted to true, if set to `false` files will be created with epoch timestamp
+
 ## Screenshots
 
 Screenshots are automatically added to HTML reports, including that of failed tests (unless you have disabled `screenshotOnRunFailure`).

--- a/docs/json-report.md
+++ b/docs/json-report.md
@@ -14,6 +14,8 @@ JSON reports can be enabled using the `json.enabled` property. The preprocessor 
 
 The report is outputted to `cucumber-report.json` in the project directory, but can be configured through the `json.output` property.
 
+`json.override` is a boolean flag defaulted to true, if set to `false` files will be created with epoch timestamp
+
 ## Screenshots
 
 Screenshots are automatically added to JSON reports, including that of failed tests (unless you have disabled `screenshotOnRunFailure`).

--- a/lib/helpers/paths.ts
+++ b/lib/helpers/paths.ts
@@ -1,6 +1,10 @@
 import path from "path";
 
-export function ensureIsAbsolute(root: string, maybeRelativePath: string) {
+export function ensureIsAbsolute(root: string, maybeRelativePath: string, override:boolean = true, fileSuffix: string = '') {
+
+  if (!override) {
+    maybeRelativePath += '-' + getEpochTime() + fileSuffix;
+  }
   if (path.isAbsolute(maybeRelativePath)) {
     return maybeRelativePath;
   } else {
@@ -15,3 +19,7 @@ export function ensureIsRelative(root: string, maybeRelativePath: string) {
     return maybeRelativePath;
   }
 }
+
+const getEpochTime = (): string => {
+  return new Date().getTime().toString();
+};

--- a/lib/plugin-event-handlers.ts
+++ b/lib/plugin-event-handlers.ts
@@ -361,7 +361,9 @@ export async function afterRunHandler(config: Cypress.PluginConfigOptions) {
   if (preprocessor.json.enabled) {
     const jsonPath = ensureIsAbsolute(
       config.projectRoot,
-      preprocessor.json.output
+      preprocessor.json.output,
+      preprocessor.json.override,
+      '.json'
     );
 
     await fs.mkdir(path.dirname(jsonPath), { recursive: true });
@@ -390,7 +392,9 @@ export async function afterRunHandler(config: Cypress.PluginConfigOptions) {
   if (preprocessor.html.enabled) {
     const htmlPath = ensureIsAbsolute(
       config.projectRoot,
-      preprocessor.html.output
+      preprocessor.html.output,
+      preprocessor.json.override,
+      '.html'
     );
 
     await fs.mkdir(path.dirname(htmlPath), { recursive: true });

--- a/lib/preprocessor-configuration.ts
+++ b/lib/preprocessor-configuration.ts
@@ -410,8 +410,10 @@ interface IEnvironmentOverrides {
   messagesOutput?: string;
   jsonEnabled?: boolean;
   jsonOutput?: string;
+  jsonOverride?: boolean;
   htmlEnabled?: boolean;
   htmlOutput?: string;
+  htmlOverride?: boolean;
   prettyEnabled?: boolean;
   filterSpecsMixedMode?: FilterSpecsMixedMode;
   filterSpecs?: boolean;
@@ -427,10 +429,12 @@ export interface IBaseUserConfiguration {
   json?: {
     enabled: boolean;
     output?: string;
+    override?: boolean;
   };
   html?: {
     enabled: boolean;
     output?: string;
+    override?: boolean;
   };
   pretty?: {
     enabled: boolean;
@@ -454,10 +458,12 @@ export interface IPreprocessorConfiguration {
   readonly json: {
     enabled: boolean;
     output: string;
+    override: boolean;
   };
   readonly html: {
     enabled: boolean;
     output: string;
+    override: boolean;
   };
   readonly pretty: {
     enabled: boolean;
@@ -511,6 +517,11 @@ export function combineIntoConfiguration(
       specific?.json?.output ??
       unspecific.json?.output ??
       "cucumber-report.json",
+    override:
+      overrides.jsonOverride ??
+      specific?.json?.override ??
+      unspecific.json?.override ??
+      false,  
   };
 
   const html: IPreprocessorConfiguration["html"] = {
@@ -524,6 +535,11 @@ export function combineIntoConfiguration(
       specific?.html?.output ??
       unspecific.html?.output ??
       "cucumber-report.html",
+    override:
+      overrides.htmlOverride ??
+      specific?.html?.override ??
+      unspecific.html?.override ??
+      false,  
   };
 
   const messages: IPreprocessorConfiguration["messages"] = {


### PR DESCRIPTION
I would like to add the capability to disable the auto override that is current in place. I know the naming convention needs some work and open to options.

For my use case I am running cypress in parallel threads and would like each of those threads to create a JSON/HTML report then use [ multiple-cucumber-html-reporter](https://www.npmjs.com/package/multiple-cucumber-html-reporter) to combine the json reports into a consolidated report.

I thought about adding the capability to create the cucumber report directly in preprocessor but think that loses what this lib is for.

Open to feedback but really want this please :) 