### PR TITLE
Use named export from @cucumber/html-formatter

### DIFF
--- a/lib/helpers/formatters.ts
+++ b/lib/helpers/formatters.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from "events";
 
-import CucumberHtmlStream from "@cucumber/html-formatter";
+import { CucumberHtmlStream } from "@cucumber/html-formatter";
 
 import PrettyFormatter from "@cucumber/pretty-formatter";
 

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "@cucumber/cucumber": "^10.8.0",
     "@cucumber/cucumber-expressions": "^17.1.0",
     "@cucumber/gherkin": "^28.0.0",
-    "@cucumber/html-formatter": "^21.5.0",
+    "@cucumber/html-formatter": "^21.7.0",
     "@cucumber/message-streams": "^4.0.1",
     "@cucumber/messages": "^25.0.1",
     "@cucumber/pretty-formatter": "^1.0.1",


### PR DESCRIPTION
This PR upgrades the `@cucumber/html-formatter` dependency to the latest version, and changes the import of `CucumberHtmlStream` to be from the new named export, rather than the default export. This is to free up the default export, because in future we will export a full formatter plugin from this package, and the convention with those will be using the default export.  See https://github.com/cucumber/html-formatter/pull/320 and https://github.com/cucumber/cucumber-js/discussions/2091#discussioncomment-10228427.