### PR TITLE
fix: prevent postinstall script from running when installed as dependency using pnpm

### DIFF
--- a/patches/patch.js
+++ b/patches/patch.js
@@ -4,6 +4,12 @@
  * The intention here is to only run `patch-package` during local installation, IE. during
  * development of the library and not upon installation by the users of the library.
  */
-if (process.cwd() === process.env.INIT_CWD) {
-  require("patch-package");
+const fs = require('fs');
+const path = require('path');
+
+const isInstallingAsDependency = fs.existsSync(path.join(process.cwd(), 'package.json')) &&
+  !fs.existsSync(path.join(process.cwd(), 'src'));
+
+if (!isInstallingAsDependency) {
+  require('patch-package');
 }

--- a/patches/patch.js
+++ b/patches/patch.js
@@ -4,12 +4,16 @@
  * The intention here is to only run `patch-package` during local installation, IE. during
  * development of the library and not upon installation by the users of the library.
  */
-const fs = require('fs');
-const path = require('path');
 
-const isInstallingAsDependency = fs.existsSync(path.join(process.cwd(), 'package.json')) &&
-  !fs.existsSync(path.join(process.cwd(), 'src'));
+// Check if the script is running within node_modules
+const isInNodeModules = __dirname.includes('node_modules');
 
-if (!isInstallingAsDependency) {
+// Check if the script is running in a workspace (e.g., pnpm, yarn workspaces)
+const isInWorkspace = process.env.PWD && process.env.PWD.includes('node_modules');
+
+// Determine if we should run patch-package
+const shouldRunPatchPackage = !isInNodeModules && !isInWorkspace;
+
+if (shouldRunPatchPackage) {
   require('patch-package');
 }


### PR DESCRIPTION
The `postinstall` script runs `patch-package` even when the package is installed as a dependency, causing installation failures for users who don't have `patch-package` installed in their projects. This issue is particularly evident when using `pnpm`, which handles module isolation more strictly.

**Problem:**
The `postinstall` script attempts to run `patch-package`, which isn't available in user projects, causing installation to fail.  The workaround is for the user to add patch-package as a top-level dev-dependency in their own project.

**Solution:**
This fix updates `patches/patch.js` to check if the script is running inside a `node_modules` directory. If it is, the script assumes it's being installed as a dependency and skips running `patch-package`.

**Compatibility:**
Tested with `npm`, `pnpm`, and `yarn`. The fix works across all package managers.

**Testing:**
- Verified that `postinstall` runs during local development.
- Confirmed that installation succeeds without errors in a test project.
