### PR TITLE
Bump 'esbuild' version to prevent vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,7 +108,7 @@
     "@typescript-eslint/parser": "^8.0.0",
     "ast-types": "^0.15.2",
     "cypress": "^11.0.0 || ^12.0.0 || ^13.0.0 || ^14.0.0",
-    "esbuild": "^0.23.1",
+    "esbuild": "^0.25.1",
     "eslint": "^9.8.0",
     "genversion": "^3.2.0",
     "jsdom": "^24.1.1",


### PR DESCRIPTION
This PR updates esbuild to prevent a Dependabot alert.
See https://github.com/evanw/esbuild/security/advisories/GHSA-67mh-4wv8-2f99

The bug affects  esbuild `<= 0.24.2`. It was patched in `0.25.0`.

It is marked as "Moderate" serverity (5.3 /10)

