### PR TITLE
Fix crash in after:spec when reloading after the last test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ Other changes:
 
 - Handle even more corner cases related to reload-behavior, fixes [#1362](https://github.com/badeball/cypress-cucumber-preprocessor/issues/1362).
 
+- Don't crash `after:spec` when reload-behavior (pre-v15.18.0) is triggered after the last test has finished, eg. by a browser (GPU / renderer) crash that makes Cypress recover by re-firing `before:spec`. Previously this threw `Unexpected state in afterSpecHandler: has-reloaded`; the already-completed messages are now preserved in the report as usual.
+
 ## v25.0.0
 
 Breaking changes:

--- a/debug/README.md
+++ b/debug/README.md
@@ -1,0 +1,35 @@
+# Debug harnesses
+
+Standalone scripts for reproducing bugs against the compiled plugin (`dist/`).
+They are not part of the published package or the test suite.
+
+## `repro-has-reloaded.js`
+
+Reproduces `Unexpected state in afterSpecHandler: has-reloaded`
+([#1365](https://github.com/badeball/cypress-cucumber-preprocessor/pull/1365)).
+
+The real-world trigger is a mid/late-spec browser (GPU / renderer) crash on
+Cypress `<15.18.0`: Cypress recovers by re-firing `before:spec` *after* the last
+scenario has finished, so the state machine reaches `after:spec` while still in
+`has-reloaded`. That crash is non-deterministic and can't be scripted in a
+`.feature`, so this harness drives the compiled state machine through the exact
+resulting event sequence instead. The equivalent assertion also lives in
+[`lib/plugin-event-handlers.test.ts`](../lib/plugin-event-handlers.test.ts).
+
+### Prerequisites
+
+```bash
+npm install --no-save cypress@15.15.0   # must be <15.18.0 (state is unreachable otherwise)
+npm run build                            # build master to see the crash, the fix to see it pass
+```
+
+### Run
+
+```bash
+node debug/repro-has-reloaded.js                                   # plain
+DEBUG=cypress-cucumber-preprocessor node debug/repro-has-reloaded.js   # + internal tracing
+node --inspect-brk debug/repro-has-reloaded.js                     # step in a debugger
+```
+
+On `master` it prints `CRASHED (bug present)` with the exact error; with the fix
+it completes and confirms the finished scenario is preserved in the report.

--- a/debug/repro-cypress/.cypress-cucumber-preprocessorrc.json
+++ b/debug/repro-cypress/.cypress-cucumber-preprocessorrc.json
@@ -1,0 +1,4 @@
+{
+  "messages": { "enabled": true, "output": "cucumber-messages.ndjson" },
+  "json": { "enabled": true, "output": "cucumber-report.json" }
+}

--- a/debug/repro-cypress/README.md
+++ b/debug/repro-cypress/README.md
@@ -1,0 +1,79 @@
+# Cypress reproduction — `afterSpecHandler: has-reloaded`
+
+A minimal, self-contained Cypress project that reproduces:
+
+```
+An error was thrown in your plugins file while executing the handler for the
+after:spec event.
+Error: Unexpected state in afterSpecHandler: has-reloaded
+```
+
+## Why this works
+
+On Cypress `<15.18.0`, reload-behavior re-fires `before:spec`. A **GPU-process
+crash** makes Cypress recover by re-firing `before:spec` (state → `has-reloaded`)
+without re-running the spec, so `after:spec` fires while still in `has-reloaded`
+and `afterSpecHandler` throws.
+
+It must be a **GPU-process** crash, not a renderer crash: `afterSpecHandler`
+already catches renderer crashes (`We detected that the … process just crashed`)
+via `browserCrashExprCol` and skips the report. A GPU crash isn't matched, so it
+slips through to the unhandled `has-reloaded` state. This is the same class of
+crash observed in the field (`GPU process exited unexpectedly: exit_code=15`),
+just triggered deterministically here via the CDP command
+`Browser.crashGpuProcess`.
+
+## The scenario
+
+`cypress/e2e/a.feature` renders a dashboard for many accounts (a Scenario
+Outline with 12 examples — the field crash appeared on specs with >10
+scenarios), then a final scenario crashes the GPU process. The steps do real
+navigation + assertions against `https://example.org/`, mirroring the plugin's
+own `@network` reload tests.
+
+## Prerequisites
+
+- Cypress `< 15.18.0` (this project pins `15.15.0`). On `>= 15.18.0` the
+  `has-reloaded` state is unreachable and the bug does not occur.
+- A Chromium-family browser with a GPU process (Electron or Chrome).
+- Network access **only for `crashMode=cdp`** (it visits `https://example.org/`);
+  `crashMode=memory` is fully self-contained.
+
+## Run
+
+```bash
+cd debug/repro-cypress
+npm install
+```
+
+Two switchable modes (via `--env crashMode=...`), same feature:
+
+```bash
+# cdp (default) -- deterministic: real navigation + GPU crash forced via CDP.
+npx cypress run --browser electron
+
+# memory -- organic & self-contained: no network, no CDP; renders a heavy local
+# page and exhausts GPU memory with WebGL until the GPU process crashes itself.
+npx cypress run --browser electron --env crashMode=memory
+```
+
+Use `cdp` for a reliable, shareable reproduction; use `memory` to reproduce the
+raw field scenario (natural memory pressure) — note it's timing-dependent and
+may need more scenarios or larger allocations on a high-memory machine.
+
+## Expected result
+
+- **With preprocessor `24.0.1` / current `master`:** the run fails after the
+  specs with `Unexpected state in afterSpecHandler: has-reloaded`.
+- **With the fix (PR #1365):** the run completes; the report
+  (`cucumber-messages.ndjson` / `cucumber-report.json`) is still written with the
+  completed scenario preserved.
+
+## Notes
+
+- If the GPU crash doesn't land at the right moment on your machine, increase the
+  `cy.wait(...)` in `cypress/support/step_definitions/steps.js`, or add more
+  passing scenarios before the crashing one (the field crash appeared on specs
+  with >10 scenarios under memory pressure).
+- For a browser-independent, 100%-deterministic reproduction of the same event
+  sequence, see `../repro-has-reloaded.js`.

--- a/debug/repro-cypress/cypress.config.js
+++ b/debug/repro-cypress/cypress.config.js
@@ -1,0 +1,25 @@
+const { defineConfig } = require("cypress");
+const {
+  addCucumberPreprocessorPlugin,
+} = require("@badeball/cypress-cucumber-preprocessor");
+const {
+  createEsbuildPlugin,
+} = require("@badeball/cypress-cucumber-preprocessor/esbuild");
+const createBundler = require("@bahmutov/cypress-esbuild-preprocessor");
+
+module.exports = defineConfig({
+  e2e: {
+    specPattern: "cypress/e2e/**/*.feature",
+    video: false,
+    async setupNodeEvents(on, config) {
+      await addCucumberPreprocessorPlugin(on, config);
+
+      on(
+        "file:preprocessor",
+        createBundler({ plugins: [createEsbuildPlugin(config)] }),
+      );
+
+      return config;
+    },
+  },
+});

--- a/debug/repro-cypress/cypress/e2e/a.feature
+++ b/debug/repro-cypress/cypress/e2e/a.feature
@@ -1,0 +1,34 @@
+Feature: Dashboard rendering under load
+
+  # Reproduces "Unexpected state in afterSpecHandler: has-reloaded".
+  #
+  # The Scenario Outline renders many heavy pages in one spec (the field crash
+  # appeared on specs with >10 scenarios under memory pressure). The final
+  # scenario deterministically crashes the GPU process, which makes Cypress
+  # recover by re-firing before:spec (state -> "has-reloaded") without re-running
+  # the spec, so after:spec fires while still in "has-reloaded".
+
+  Scenario Outline: render the dashboard for account <account>
+    Given I open the dashboard for account "<account>"
+    Then I see the account heading for "<account>"
+    And the dashboard has finished rendering
+
+    Examples:
+      | account |
+      | 1000    |
+      | 1001    |
+      | 1002    |
+      | 1003    |
+      | 1004    |
+      | 1005    |
+      | 1006    |
+      | 1007    |
+      | 1008    |
+      | 1009    |
+      | 1010    |
+      | 1011    |
+
+  Scenario: the GPU runs out of memory while rendering
+    Given I open the dashboard for account "1012"
+    When the GPU process runs out of memory
+    Then the report is still generated

--- a/debug/repro-cypress/cypress/fixtures/dashboard.html
+++ b/debug/repro-cypress/cypress/fixtures/dashboard.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Account Dashboard</title>
+  </head>
+  <body>
+    <h1>Account Dashboard</h1>
+    <p id="account"></p>
+    <div id="charts"></div>
+    <script>
+      // Show the account from the query string (?account=NNNN).
+      var account = new URLSearchParams(location.search).get("account") || "?";
+      document.getElementById("account").textContent = "Account " + account;
+
+      // Render a handful of WebGL canvases so each page load consumes real GPU
+      // memory -- across many scenarios this builds the pressure that, in the
+      // field, eventually crashed the GPU process (crashMode=memory).
+      var charts = document.getElementById("charts");
+      for (var i = 0; i < 8; i++) {
+        var canvas = document.createElement("canvas");
+        canvas.width = 1024;
+        canvas.height = 512;
+        var gl = canvas.getContext("webgl2") || canvas.getContext("webgl");
+        if (gl) {
+          gl.clearColor(Math.random(), Math.random(), Math.random(), 1);
+          gl.clear(gl.COLOR_BUFFER_BIT);
+        }
+        charts.appendChild(canvas);
+      }
+    </script>
+  </body>
+</html>

--- a/debug/repro-cypress/cypress/support/e2e.js
+++ b/debug/repro-cypress/cypress/support/e2e.js
@@ -1,0 +1,1 @@
+// Intentionally empty. Step definitions are auto-loaded by the preprocessor.

--- a/debug/repro-cypress/cypress/support/step_definitions/steps.js
+++ b/debug/repro-cypress/cypress/support/step_definitions/steps.js
@@ -1,0 +1,84 @@
+const { Given, When, Then } = require("@badeball/cypress-cucumber-preprocessor");
+
+/**
+ * Two reproduction modes, switchable without touching the feature:
+ *
+ *   crashMode = "cdp"    (default) Deterministic. Renders real pages
+ *                        (https://example.org) and crashes the GPU process on
+ *                        demand via CDP. Reproduces reliably on any machine.
+ *                        Run: npx cypress run --browser electron
+ *
+ *   crashMode = "memory" Organic / self-contained. Renders a heavy local page
+ *                        (no network) and exhausts GPU memory with WebGL until
+ *                        the GPU process crashes by itself -- the raw field
+ *                        scenario. No network, but timing-dependent (may need
+ *                        more scenarios / bigger allocations on a beefy box).
+ *                        Run: npx cypress run --browser electron --env crashMode=memory
+ */
+const MODE = Cypress.env("crashMode") || "cdp";
+
+Given("I open the dashboard for account {string}", (account) => {
+  if (MODE === "memory") {
+    // Self-contained heavy page (served from the project by Cypress).
+    cy.visit(`/cypress/fixtures/dashboard.html?account=${account}`);
+  } else {
+    // Real navigation, like the plugin's own @network reload tests.
+    cy.visit(`https://example.org/?account=${account}`);
+  }
+});
+
+Then("I see the account heading for {string}", () => {
+  cy.get("h1").should("be.visible");
+});
+
+Then("the dashboard has finished rendering", () => {
+  cy.get("body").should("be.visible");
+});
+
+When("the GPU process runs out of memory", () => {
+  if (MODE === "memory") {
+    // Exhaust GPU memory from within the page until the GPU process dies.
+    cy.window().then((win) => {
+      for (let i = 0; i < 400; i++) {
+        const canvas = win.document.createElement("canvas");
+        canvas.width = 4096;
+        canvas.height = 4096;
+        const gl =
+          canvas.getContext("webgl2") || canvas.getContext("webgl");
+        if (gl) {
+          const tex = gl.createTexture();
+          gl.bindTexture(gl.TEXTURE_2D, tex);
+          gl.texImage2D(
+            gl.TEXTURE_2D,
+            0,
+            gl.RGBA,
+            4096,
+            4096,
+            0,
+            gl.RGBA,
+            gl.UNSIGNED_BYTE,
+            null,
+          );
+        }
+        win.document.body.appendChild(canvas);
+      }
+    });
+  } else {
+    // Deterministic GPU-process crash via CDP. A *GPU* crash (unlike a
+    // *renderer* crash, which afterSpecHandler catches via browserCrashExprCol)
+    // is not matched, so Cypress's recovery leaves the plugin in "has-reloaded"
+    // when after:spec fires -- the field signature "GPU process exited
+    // unexpectedly: exit_code=15", triggered on demand.
+    cy.wrap(null).then(() =>
+      Cypress.automation("remote:debugger:protocol", {
+        command: "Browser.crashGpuProcess",
+        params: {},
+      }),
+    );
+  }
+  cy.wait(5000); // let the crash / recovery happen before the spec ends
+});
+
+Then("the report is still generated", () => {
+  cy.log("after:spec must not crash on the has-reloaded state");
+});

--- a/debug/repro-cypress/package.json
+++ b/debug/repro-cypress/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "has-reloaded-repro",
+  "private": true,
+  "version": "0.0.0",
+  "description": "Minimal Cypress project reproducing the afterSpecHandler has-reloaded crash",
+  "scripts": {
+    "test": "cypress run --browser electron"
+  },
+  "devDependencies": {
+    "@badeball/cypress-cucumber-preprocessor": "^24.0.1",
+    "@bahmutov/cypress-esbuild-preprocessor": "^2.2.0",
+    "cypress": "15.15.0",
+    "esbuild": "^0.24.0"
+  }
+}

--- a/debug/repro-has-reloaded.js
+++ b/debug/repro-has-reloaded.js
@@ -1,0 +1,137 @@
+/*
+ * ============================================================================
+ *  Reproduction harness: "Unexpected state in afterSpecHandler: has-reloaded"
+ * ============================================================================
+ *
+ * WHAT IT REPRODUCES
+ *   The crash reported in https://github.com/badeball/cypress-cucumber-preprocessor/pull/1365.
+ *   It drives the COMPILED plugin state machine (dist/) through the event
+ *   sequence that a mid/late-spec browser (GPU / renderer) crash produces on
+ *   Cypress < 15.18.0:
+ *
+ *     before:run
+ *       -> before:spec                     (state: before-spec)
+ *       -> specEnvelopes                   (state: received-envelopes)
+ *       -> testCaseStarted                 (state: test-started)
+ *       -> testCaseFinished                (state: test-finished)   << scenario passes
+ *       -> before:spec  (crash re-fires!)  (state: has-reloaded)    << reload, no re-run
+ *       -> after:spec                      (THROWS on master / OK once fixed)
+ *       -> after:run                       (writes the report)
+ *
+ *   A browser crash re-fires before:spec but does NOT re-run the spec, so the
+ *   plugin never receives a fresh specEnvelopes and is stuck in "has-reloaded"
+ *   when after:spec arrives.
+ *
+ * WHY A SCRIPT AND NOT A CYPRESS SPEC
+ *   The real-world trigger is a non-deterministic renderer/GPU crash, which
+ *   cannot be scripted reliably in a .feature. This harness reproduces the
+ *   exact resulting event sequence deterministically. The equivalent assertion
+ *   also lives in lib/plugin-event-handlers.test.ts (run via `npm run test:unit`).
+ *
+ * PREREQUISITES
+ *   - Cypress < 15.18.0 installed (on >= 15.18.0 the state is unreachable):
+ *         npm install --no-save cypress@15.15.0
+ *   - The plugin built to dist/:
+ *         npm run build
+ *
+ * RUN (from anywhere)
+ *     node debug/repro-has-reloaded.js
+ *   With internal plugin tracing:
+ *     DEBUG=cypress-cucumber-preprocessor node debug/repro-has-reloaded.js
+ *   Step through in a debugger:
+ *     node --inspect-brk debug/repro-has-reloaded.js
+ *   ... then breakpoint dist/plugin-event-handlers.js afterSpecHandler.
+ * ============================================================================
+ */
+const os = require("node:os");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const REPO = process.env.REPO || path.join(__dirname, "..");
+const H = require(path.join(REPO, "dist/plugin-event-handlers.js"));
+
+const TS = { seconds: 0, nanos: 0 };
+
+async function step(label, fn) {
+  process.stdout.write(`  -> ${label} ... `);
+  await fn();
+  console.log("ok");
+}
+
+async function main() {
+  const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ccp-repro-"));
+  fs.writeFileSync(
+    path.join(projectRoot, ".cypress-cucumber-preprocessorrc.json"),
+    JSON.stringify({ messages: { enabled: true, output: "messages.ndjson" } }),
+  );
+
+  const config = {
+    isTextTerminal: true,
+    projectRoot,
+    testingType: "e2e",
+    reporter: "spec",
+    env: { testRunStartedId: "trs-1" },
+  };
+  const spec = {
+    name: "a.feature",
+    relative: "cypress/e2e/a.feature",
+    absolute: path.join(projectRoot, "cypress", "e2e", "a.feature"),
+    fileExtension: ".feature",
+    fileName: "a",
+    specType: "integration",
+  };
+  const specResults = { error: null, tests: [], relative: spec.relative };
+  const runResults = { totalFailed: 0, runs: [] };
+
+  console.log(`project: ${projectRoot}\n`);
+
+  await step("before:run", () => H.beforeRunHandler(config));
+  await step("before:spec", () => H.beforeSpecHandler(config, spec));
+  await step("task: specEnvelopes", () =>
+    H.specEnvelopesHandler(config, {
+      messages: [{ testCase: { id: "tc-1", pickleId: "p-1", testSteps: [] } }],
+    }),
+  );
+  await step("task: testCaseStarted", () =>
+    H.testCaseStartedHandler(config, {
+      id: "tcs-1",
+      testCaseId: "tc-1",
+      attempt: 0,
+      timestamp: TS,
+    }),
+  );
+  await step("task: testCaseFinished (scenario passes)", () =>
+    H.testCaseFinishedHandler(config, {
+      testCaseStartedId: "tcs-1",
+      willBeRetried: false,
+      timestamp: TS,
+    }),
+  );
+  await step("before:spec AGAIN (browser crash recovery)", () =>
+    H.beforeSpecHandler(config, spec),
+  );
+  await step("after:spec  <-- the crashing call", () =>
+    H.afterSpecHandler(config, spec, specResults),
+  );
+  await step("after:run", () => H.afterRunHandler(config, runResults));
+
+  const report = fs.readFileSync(
+    path.join(projectRoot, "messages.ndjson"),
+    "utf8",
+  );
+  const preserved =
+    /"testCaseStarted"/.test(report) && /"testCaseFinished"/.test(report);
+  console.log(
+    `\nreport written: ${path.join(projectRoot, "messages.ndjson")}` +
+      `\nscenario preserved in report: ${preserved ? "YES" : "NO"}`,
+  );
+}
+
+main().then(
+  () => console.log("\n==> RESULT: completed without crashing (fix present)."),
+  (err) => {
+    console.log("\n==> RESULT: CRASHED (bug present):");
+    console.log("    " + (err && err.message ? err.message : String(err)));
+    process.exitCode = 1;
+  },
+);

--- a/lib/plugin-event-handlers.test.ts
+++ b/lib/plugin-event-handlers.test.ts
@@ -1,0 +1,120 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import * as messages from "@cucumber/messages";
+import { version as cypressVersion } from "cypress/package.json";
+
+import {
+  afterRunHandler,
+  afterSpecHandler,
+  beforeRunHandler,
+  beforeSpecHandler,
+  specEnvelopesHandler,
+  testCaseFinishedHandler,
+  testCaseStartedHandler,
+} from "./plugin-event-handlers";
+
+/**
+ * The "has-reloaded" state is only reachable prior to Cypress v15.18.0, where a
+ * reload re-fires before:spec. On later versions the state machine never enters
+ * it, so there's nothing to assert.
+ */
+function isPre15_18() {
+  const [major, minor] = cypressVersion
+    .split(".")
+    .map((part) => parseInt(part, 10));
+  return major < 15 || (major === 15 && minor < 18);
+}
+
+const TIMESTAMP: messages.Timestamp = { seconds: 0, nanos: 0 };
+
+/**
+ * A browser (GPU / renderer) crash mid-spec makes Cypress recover by re-firing
+ * before:spec *after* the last scenario has already finished, without the spec's
+ * before-hook re-emitting spec envelopes. This lands the state machine in
+ * "has-reloaded" when after:spec fires. This suite drives that exact sequence
+ * against the real handlers and asserts that after:spec doesn't crash and that
+ * the already-completed messages are preserved in the report (rather than being
+ * discarded or throwing "Unexpected state in afterSpecHandler: has-reloaded").
+ */
+(isPre15_18() ? describe : describe.skip)(
+  "reload-behavior after the last test (crash recovery)",
+  () => {
+    it("doesn't crash after:spec and preserves the report", async () => {
+      const projectRoot = fs.mkdtempSync(path.join(os.tmpdir(), "ccp-test-"));
+
+      fs.writeFileSync(
+        path.join(projectRoot, ".cypress-cucumber-preprocessorrc.json"),
+        JSON.stringify({
+          messages: { enabled: true, output: "messages.ndjson" },
+        }),
+      );
+
+      const config = {
+        isTextTerminal: true,
+        projectRoot,
+        testingType: "e2e",
+        reporter: "spec",
+        env: { testRunStartedId: "test-run-started-id" },
+      } as unknown as Cypress.PluginConfigOptions;
+
+      const spec = {
+        name: "a.feature",
+        relative: "cypress/e2e/a.feature",
+        absolute: path.join(projectRoot, "cypress", "e2e", "a.feature"),
+        fileExtension: ".feature",
+        fileName: "a",
+        specType: "integration",
+      } as Cypress.Spec;
+
+      await beforeRunHandler(config);
+      await beforeSpecHandler(config, spec);
+      await specEnvelopesHandler(config, {
+        messages: [
+          { testCase: { id: "tc-1", pickleId: "p-1", testSteps: [] } },
+        ],
+      });
+
+      // A scenario runs to completion -> state "test-finished".
+      await testCaseStartedHandler(config, {
+        id: "tcs-1",
+        testCaseId: "tc-1",
+        attempt: 0,
+        timestamp: TIMESTAMP,
+      });
+      await testCaseFinishedHandler(config, {
+        testCaseStartedId: "tcs-1",
+        willBeRetried: false,
+        timestamp: TIMESTAMP,
+      });
+
+      // Browser crash recovery re-fires before:spec -> state "has-reloaded".
+      await beforeSpecHandler(config, spec);
+
+      // Used to throw "Unexpected state in afterSpecHandler: has-reloaded".
+      await afterSpecHandler(config, spec, {
+        error: null,
+        tests: [],
+        relative: spec.relative,
+      } as unknown as CypressCommandLine.RunResult);
+
+      await afterRunHandler(config, {
+        totalFailed: 0,
+        runs: [],
+      } as unknown as CypressCommandLine.CypressRunResult);
+
+      const report = fs.readFileSync(
+        path.join(projectRoot, "messages.ndjson"),
+        "utf8",
+      );
+
+      // The completed scenario must be preserved in the report, not discarded.
+      assert.match(report, /"testCaseStarted"/);
+      assert.match(report, /"testCaseFinished"/);
+      assert.match(report, /tcs-1/);
+      assert.match(report, /tc-1/);
+    });
+  },
+);

--- a/lib/plugin-event-handlers.ts
+++ b/lib/plugin-event-handlers.ts
@@ -707,11 +707,21 @@ export async function afterSpecHandler(
     return;
   }
 
+  /**
+   * The "has-reloaded" states below can occur when reload-behavior (pre-v15.18.0)
+   * is triggered after all test bodies have completed, typically in an after() /
+   * afterEach() hook of the last test. Cypress re-fires before:spec, moving us into
+   * a "has-reloaded" state, but since the suite is already done, no test re-runs and
+   * after:spec fires directly. In both cases `messages.current` already holds the
+   * completed test messages, so the report is generated as usual further below.
+   */
   switch (state.state) {
     case "test-finished": // This is the normal case.
     case "run-hook-finished": // In case of AfterAll hooks.
     case "before-spec": // This can happen if a spec doesn't contain any tests.
     case "received-envelopes": // This can happen in case of a failing beforeEach hook.
+    case "has-reloaded": // In case of reloading after the last test has finished.
+    case "has-reloaded-received-envelopes": // Ditto, with re-hydrated envelopes.
       break;
     default:
       throw createStateError("afterSpecHandler", state.state);


### PR DESCRIPTION
Reload-behavior on Cypress <15.18.0 re-fires before:spec. When the reload occurs once every test body has already finished (typically in an after() / afterEach() hook), the plugin enters a "has-reloaded" state but no test re-runs, so after:spec fires directly. afterSpecHandler did not handle this state (nor its "has-reloaded-received-envelopes" sibling) and threw:

    Unexpected state in afterSpecHandler: has-reloaded

which surfaced to users as a misleading "some other plugin is overwriting this plugin's event handlers" error.

Both states already carry the completed messages in `messages.current`, so they now flow through the normal report-generation path instead of throwing.

Adds a regression feature (gated to Cypress <15.18.0, where the state is reachable) plus an isPre15_18 helper and matching cucumber tag hook.